### PR TITLE
Introduce IEngine abstraction, unit tests, and smart-pointer ownership cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project overview
+
+`sunlight` is a C++17 2D game engine library (zlib license) for building tile-map based games. It wraps [raylib](https://www.raylib.com/) for rendering/input/audio and [libtmx](https://github.com/baylej/tmx.git) for loading Tiled `.tmx`/`.tsx` maps, exposing a manager-style API for maps, sprites, collisions, and graphics primitives.
+
+## Build
+
+Requires CMake 3.24+, system zlib, and (unless `-DUSE_LOCAL_LIBXML2` is passed) libxml2/raylib/tmx are fetched automatically via `FetchContent` (raylib pinned to `5.5`; libxml2/tmx track `master`). On Linux, raylib's own system dependencies must be installed first (see raylib's wiki).
+
+```shell
+cmake -B build -S .
+cmake --build build --target sunlight -j 4
+```
+
+Samples are opt-in (`OFF` by default):
+
+```shell
+cmake -B build -S . -DBUILD_LIBRARY_SAMPLES=ON
+cmake --build build -j 4
+```
+
+This builds `sprite_test` and `tilemaprenderer_test` and copies the raylib/tmx/LibXml2/sunlight shared libs next to each executable (required at runtime, via the `*_copy_binaries` custom targets). Each sample takes its own directory as `argv[1]` and resolves resource paths relative to it, e.g.:
+
+```shell
+./build/samples/tilemaprenderer/tilemaprenderer_test samples/tilemaprenderer/
+```
+
+There is no test suite (`CTest` is included by the sample `CMakeLists.txt` but no tests are registered), and no linter/formatter config in the repo.
+
+For a debug build: `cmake -B build -S . -DCMAKE_C_FLAGS="-g2" -DCMAKE_CXX_FLAGS="-g2"` (or the `SUNLIGHT_DEBUG_SYMBOLS_UNIX` option, on by default on Mac/Linux).
+
+## Architecture
+
+The core library lives in `src/`, one namespace per module under `SunLight::<Module>`. `src/CMakeLists.txt` globs all `.cpp`/`.h` recursively into a single `sunlight` target — re-run `cmake -B build -S .` after adding new source files so the glob picks them up.
+
+### Module map
+- `base` — `Object` (opaque `void*`-holding base class), `GraphicObject`, `Viewport`, `stColor`, and `primitives.h` (`stRectangle`, `stVector2D`, `TextureHandle` — backend-agnostic geometry/handle types).
+- `tilemap` — interfaces/POD structs describing TMX map data (`ITileMap`, `stLayer`, `stTile`, `stDimension2D`, ...); pure shared types, no implementation.
+- `renderer` — `TileMapRenderer`, the engine's central class: owns the window/game loop, camera/viewport, input dispatch, sprite map, tile animation, and low-level drawing primitives (Bresenham line, midpoint ellipse, polygon).
+- `collision` — `CollisionManager`: layer-based collider rules (`ColliderToColliderRule`, `ColliderToTileLayerRule`) with an observer-style `ICollisionListener`.
+- `canvas` / `sprite` — `Canvas`/`TextureCanvas` (single animated texture with tiling/zoom-aware blit) and `Sprite` (named sequences of `TextureCanvas`s, e.g. walk-cycle frames).
+- `input` — `IInputHandler` + `InputHandlerFactory`, backed by `input/raylib/RaylibInputHandler`.
+- `sound` — `SoundManager` behind `ISound`, backed by `sound/raylib/RayLibSound`.
+- `engines` — `IEngine` (`SetPixel`, `DrawTexture`, `DrawTextureTiled`, `LoadTexture`/`UnloadTexture`) + `EngineFactory::GetEngine()`, backed by `engines/raylib/RaylibEngine`. The seam through which the actual raylib draw calls happen.
+- `scripting`, `concurrent`, `general` — script listener hooks, a `Timer` utility, `Helper::Random()`.
+
+### Backend abstraction pattern
+
+Every raylib-touching subsystem follows the same shape: an interface at the module root (`IInputHandler`, `ISound`, `IEngine`) + a factory owning a single `#if DEFAULT_ENGINE == 1 ... #else #error` switch, + a concrete `*/raylib/Raylib*` implementation. `DEFAULT_ENGINE` is injected by `src/CMakeLists.txt` via `-DDEFAULT_ENGINE=<n>` (only `1` = raylib exists today). Adding a second backend means: implement the interface, extend the one `#if` block in that module's factory `.cpp` — call sites elsewhere should never need raylib types directly.
+
+`engines/EngineFactory`/`IEngine` is the newest and most complete instance of this pattern — `TextureCanvas` and `TileMapRenderer` route all texture load/unload/draw calls through it and no longer need `<raylib.h>` in their own headers. Two things are deliberately **not yet** routed through it (each would be its own larger task):
+- `TileMapRenderer`'s window lifecycle (`InitWindow`, `WindowShouldClose`, `BeginDrawing`/`EndDrawing`, `SetTargetFPS`, `ClearBackground`) still calls raylib directly.
+- `sound/soundmanager.cpp` has its own, older copy of the `#if DEFAULT_ENGINE` switch (predates `EngineFactory`, not yet consolidated into it).
+
+**Gotcha:** `SunLight::Input::KeyboardKey` is a distinct enum from raylib's own global `KeyboardKey`, even though the numeric values match. Because both are named `KeyboardKey` and there is no `using namespace SunLight::Input`, an unqualified `KeyboardKey` inside `namespace SunLight::Renderer` silently resolves to whichever one happens to be visible via prior `#include`s — not necessarily the intended one. Always fully qualify as `SunLight::Input::KeyboardKey` in new code (see `TileMapRenderer::SetExitKey`, which was fixed for exactly this bug).
+
+### Native geometry/texture types
+
+`base/primitives.h` defines `stRectangle`/`stVector2D` (float x/y/width/height — sub-pixel precision for zoom/scale math) and `TextureHandle` (`typedef void*`: an opaque handle owned by whichever `IEngine` loaded it, cast back to the concrete texture type only inside that engine's own `.cpp`). Prefer these over raylib's `Rectangle`/`Vector2`/`Texture2D` in any new backend-agnostic code.
+
+## Known issues (tracked in `doc/`)
+- `doc/FIXME.txt`: access violation when map scroll goes past viewport boundaries.
+- `doc/TODO.txt`: no isometric/hexagonal map support; missing some gamepad face-button bindings; per-layer parallax scrolling and per-object property management (opacity/visible/position) not implemented; sprite/layer draw-order still being finished.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ cmake_minimum_required (VERSION 3.24)
 project (sunlight_all)
 
 option(BUILD_LIBRARY_SAMPLES "Build SunLight library samples" OFF)
+option(BUILD_LIBRARY_TESTS "Build SunLight library unit tests" OFF)
 
 # Core library
 add_subdirectory(src)
@@ -30,3 +31,9 @@ if(BUILD_LIBRARY_SAMPLES)
     add_subdirectory(samples/tilemaprenderer)
     add_subdirectory(samples/sprite)
 endif(BUILD_LIBRARY_SAMPLES)
+
+# Unit tests
+if(BUILD_LIBRARY_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif(BUILD_LIBRARY_TESTS)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 `sunlight` is an open source library written in C++ to make 2D games. Overall, its present main features include a manager that can deal with map, collision, sprites and graphic primitives.
 
-[raylib](https://www.raylib.com/) was used for graphic backend, but the project aims to be extended to SDL and many others.
+[raylib](https://www.raylib.com/) was used for graphic backend, but the project aims to be extended to SDL and many others. Rendering is exposed through an `IEngine` interface (`src/engines/`) so a new backend only needs its own implementation plus one line in the engine factory, without touching the rest of the codebase.
 </div>
 
 ## Table of Contents :pushpin:

--- a/samples/sprite/sprite_test.cpp
+++ b/samples/sprite/sprite_test.cpp
@@ -25,7 +25,6 @@
 
 int main( int argc, char **argv ) {
     std :: string   strBasePath;
-    World           *pWorld;
     bool            bRet;
 
     // Check command line arguments
@@ -34,10 +33,10 @@ int main( int argc, char **argv ) {
         return EXIT_FAILURE;
     }
 
-    strBasePath = argv[1];  
-    pWorld = new World( strBasePath );
-    bRet = pWorld -> Run();
-    delete pWorld;
+    strBasePath = argv[1];
+
+    World world( strBasePath );
+    bRet = world.Run();
 
     if( !bRet ){
         return EXIT_FAILURE;

--- a/samples/sprite/world.cpp
+++ b/samples/sprite/world.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "world.h"
+#include <cstdio>
 
 #define __DISPLAY_W                 1260
 #define __DISPLAY_H                 920
@@ -195,12 +196,12 @@ bool World :: Run( void )  {
     strMapFile = m_strBasePath + __TMX_MAP_FILE;
 
     if( !m_pRenderer -> LoadMap( strMapFile.c_str(), __DEFAULT_MAP_ALIGNMENT ) )  {
-        perror("Error loading map\n" );
+        fprintf( stderr, "Error loading map\n" );
         return false;
     } 
 
     if( !LoadSprites() )  {
-        perror("Error loading sprites\n" );
+        fprintf( stderr, "Error loading sprites\n" );
         return false;
     }
 

--- a/samples/sprite/world.cpp
+++ b/samples/sprite/world.cpp
@@ -105,7 +105,7 @@ void World :: ResetZoom( SunLight :: Input :: ControllerType type, int nId )  {
 
 bool World :: LoadSprites( void ) {
 
-    if( ( m_pRenderer != NULL ) && m_pCanvasSunny -> Load( m_strBasePath + __SUNNY_SPRITE_IDLE ) ) {
+    if( m_pCanvasSunny -> Load( m_strBasePath + __SUNNY_SPRITE_IDLE ) ) {
         SunLight :: TileMap :: stDimension2D    dim;
 
         dim.pos.x = 100;
@@ -116,7 +116,7 @@ bool World :: LoadSprites( void ) {
         m_pCanvasSunny -> SetTileSize( 32 );
         m_pCanvasSunny -> SetAnimationMode( SunLight :: Canvas :: AnimationMode :: TEXTURE_ANIMATION_MODE_AUTOMATIC_CIRCULAR );
         m_pCanvasSunny -> SetDimension2D( dim );
-        m_pSpriteSunny -> AddTextureSequence( 0, m_pCanvasSunny, __SUNNY_SPRITE_IDLE_DELAY );
+        m_pSpriteSunny -> AddTextureSequence( 0, m_pCanvasSunny.get(), __SUNNY_SPRITE_IDLE_DELAY );
         m_pSpriteSunny -> SetActiveTextureSequence( 0 );
         m_pSpriteSunny -> SetVisible( true );
 
@@ -135,22 +135,13 @@ bool World :: LoadSprites( void ) {
 World :: World( std :: string strBasePath )  {
 
     m_strBasePath = strBasePath;
-    m_pRenderer = new SunLight :: Renderer :: TileMapRenderer( __DISPLAY_W,
-                                                               __DISPLAY_H,
-                                                               __GAME_NAME,
-                                                               __FRAMES_PER_SECOND,
-                                                               false );
-    m_pSpriteSunny = new SunLight :: Sprite :: Sprite();
-    m_pCanvasSunny = new SunLight :: Canvas :: TextureCanvas();
-}
-
-/**
- * @brief Deconstructor. Finalizes all class data.
- */
-World :: ~World( void )  {
-    delete m_pRenderer;
-    delete m_pSpriteSunny;
-    delete m_pCanvasSunny;
+    m_pRenderer = std :: make_unique<SunLight :: Renderer :: TileMapRenderer>( __DISPLAY_W,
+                                                                               __DISPLAY_H,
+                                                                               __GAME_NAME,
+                                                                               __FRAMES_PER_SECOND,
+                                                                               false );
+    m_pSpriteSunny = std :: make_unique<SunLight :: Sprite :: Sprite>();
+    m_pCanvasSunny = std :: make_unique<SunLight :: Canvas :: TextureCanvas>();
 }
 
 /**

--- a/samples/sprite/world.h
+++ b/samples/sprite/world.h
@@ -23,6 +23,7 @@
 
  #include "renderer/tilemaprenderer.h"
  #include "sprite/sprite.h"
+ #include <memory>
  #include <string>
 
 
@@ -31,9 +32,9 @@
  */
 class World {
 
-    SunLight :: Renderer :: TileMapRenderer  *m_pRenderer = NULL;
-    SunLight :: Sprite :: Sprite             *m_pSpriteSunny = NULL;
-    SunLight :: Canvas :: TextureCanvas      *m_pCanvasSunny = NULL;
+    std :: unique_ptr<SunLight :: Renderer :: TileMapRenderer>  m_pRenderer;
+    std :: unique_ptr<SunLight :: Sprite :: Sprite>             m_pSpriteSunny;
+    std :: unique_ptr<SunLight :: Canvas :: TextureCanvas>      m_pCanvasSunny;
     std :: string m_strBasePath;
 
     void MoveCameraUp( SunLight :: Input :: ControllerType type, int nId );    
@@ -49,7 +50,6 @@ class World {
     public :
 
     World( std :: string strBasePath );
-    ~World( void );
 
     bool Run( void );
 };

--- a/samples/tilemaprenderer/tilemaprenderer_test.cpp
+++ b/samples/tilemaprenderer/tilemaprenderer_test.cpp
@@ -25,7 +25,6 @@
 
 int main( int argc, char **argv ) {
     std :: string   strBasePath;
-    World           *pWorld;
     bool            bRet;
 
     // Check command line arguments
@@ -34,10 +33,10 @@ int main( int argc, char **argv ) {
         return EXIT_FAILURE;
     }
 
-    strBasePath = argv[1];  
-    pWorld = new World( strBasePath );
-    bRet = pWorld -> Run();
-    delete pWorld;
+    strBasePath = argv[1];
+
+    World world( strBasePath );
+    bRet = world.Run();
 
     if( !bRet ){
         return EXIT_FAILURE;

--- a/samples/tilemaprenderer/tilemaprenderer_test.cpp
+++ b/samples/tilemaprenderer/tilemaprenderer_test.cpp
@@ -20,6 +20,7 @@
 
 #include "world.h"
 #include <string>
+#include <cstdio>
 
 
 int main( int argc, char **argv ) {
@@ -29,7 +30,7 @@ int main( int argc, char **argv ) {
 
     // Check command line arguments
     if( argc < 2 )  {
-        perror( "Invalid command line arguments" );
+        fprintf( stderr, "Invalid command line arguments\n" );
         return EXIT_FAILURE;
     }
 

--- a/samples/tilemaprenderer/world.cpp
+++ b/samples/tilemaprenderer/world.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "world.h"
+#include <cstdio>
 
 #define __DISPLAY_W                 1260
 #define __DISPLAY_H                 920
@@ -164,7 +165,7 @@ bool World :: Run( void )  {
     strMapFile = m_strBasePath + __TMX_MAP_FILE;
 
     if( !m_pRenderer -> LoadMap( strMapFile.c_str(), __DEFAULT_MAP_ALIGNMENT ) )  {
-        perror("Error loading map\n" );
+        fprintf( stderr, "Error loading map\n" );
         return false;
     } 
 

--- a/samples/tilemaprenderer/world.cpp
+++ b/samples/tilemaprenderer/world.cpp
@@ -108,18 +108,11 @@ void World :: ResetZoom( SunLight :: Input :: ControllerType type, int nId )  {
 World :: World( std :: string strBasePath )  {
 
     m_strBasePath = strBasePath;
-    m_pRenderer = new SunLight :: Renderer :: TileMapRenderer( __DISPLAY_W,
-                                                               __DISPLAY_H,
-                                                               __GAME_NAME,
-                                                               __FRAMES_PER_SECOND,
-                                                               false );
-}
-
-/**
- * @brief Deconstructor. Finalizes all class data.
- */
-World :: ~World( void )  {
-    delete m_pRenderer;
+    m_pRenderer = std :: make_unique<SunLight :: Renderer :: TileMapRenderer>( __DISPLAY_W,
+                                                                               __DISPLAY_H,
+                                                                               __GAME_NAME,
+                                                                               __FRAMES_PER_SECOND,
+                                                                               false );
 }
 
 /**

--- a/samples/tilemaprenderer/world.h
+++ b/samples/tilemaprenderer/world.h
@@ -22,6 +22,7 @@
  #define __WORLD_H__
 
  #include "renderer/tilemaprenderer.h"
+ #include <memory>
  #include <string>
 
 
@@ -30,7 +31,7 @@
  */
 class World {
 
-    SunLight :: Renderer :: TileMapRenderer  *m_pRenderer = NULL;
+    std :: unique_ptr<SunLight :: Renderer :: TileMapRenderer>  m_pRenderer;
     std :: string m_strBasePath;
 
     void MoveCameraUp( SunLight :: Input :: ControllerType type, int nId );    
@@ -44,7 +45,6 @@ class World {
     public :
 
     World( std :: string strBasePath );
-    ~World( void );
 
     bool Run( void );
 };

--- a/src/base/primitives.h
+++ b/src/base/primitives.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
- * 
+ *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages
  * arising from the use of this software.
@@ -18,30 +18,37 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "world.h"
-#include <string>
-#include <cstdio>
+#ifndef __PRIMITIVES_H__
+#define __PRIMITIVES_H__
 
 
-int main( int argc, char **argv ) {
-    std :: string   strBasePath;
-    World           *pWorld;
-    bool            bRet;
+namespace SunLight  {
+    namespace Base  {
+        /**
+         * Rectangle definition structure (backend-agnostic, sub-pixel precision).
+         */
+        struct stRectangle  {
+            float          x;
+            float          y;
+            float          width;
+            float          height;
+        };
 
-    // Check command line arguments
-    if( argc < 2 )  {
-        fprintf( stderr, "Invalid command line arguments\n" );
-        return EXIT_FAILURE;
+        /**
+         * 2D vector definition structure (backend-agnostic, sub-pixel precision).
+         */
+        struct stVector2D  {
+            float          x;
+            float          y;
+        };
+
+        /**
+         * Opaque handle to a backend-owned texture resource.
+         * Only the active @see IEngine implementation knows its real type;
+         * every other layer just forwards this pointer around.
+         */
+        typedef void* TextureHandle;
     }
-
-    strBasePath = argv[1];  
-    pWorld = new World( strBasePath );
-    bRet = pWorld -> Run();
-    delete pWorld;
-
-    if( !bRet ){
-        return EXIT_FAILURE;
-    }
-
-    return EXIT_SUCCESS;
 }
+
+#endif /* __PRIMITIVES_H__ */

--- a/src/base/viewport.cpp
+++ b/src/base/viewport.cpp
@@ -53,8 +53,9 @@ namespace SunLight  {
 
             SetPreferredZoom( __DEFAULT_PREFERRED_ZOOM_POS );
 
-            m_pProps -> bEnabledUserZoom = __DEFAULT_USER_ZOOM_STATUS;
-            m_pProps -> fZoomFactor      = m_vZoomFactorList[m_pProps -> nPreferredZoomPos];
+            m_pProps -> bEnabledUserZoom  = __DEFAULT_USER_ZOOM_STATUS;
+            m_pProps -> nCurrentZoomPos   = m_pProps -> nPreferredZoomPos;
+            m_pProps -> fZoomFactor       = m_vZoomFactorList[m_pProps -> nPreferredZoomPos];
         }
 
         /**

--- a/src/canvas/texturecanvas.cpp
+++ b/src/canvas/texturecanvas.cpp
@@ -20,24 +20,8 @@
 
 #include "texturecanvas.h"
 #include <cstring>
-
-#ifndef DEFAULT_ENGINE
-    #error "Unexpected value of DEFAULT_ENGINE"
-#endif
-
-/*
- * In the future a better abstract way to handle raylib will be
- * implemented and the method below will be changed.
- */
-#if DEFAULT_ENGINE == 1    /* USES RAYLIB */
-    #include "engines/raylib/raylibengine.h"
-    
-    #define __DEFAULT_ENGINE         RaylibEngine
-#else
-    #error "Unknown value of DEFAULT_ENGINE"
-#endif
-
-using namespace SunLight :: Engines :: Raylib;
+#include "engines/enginefactory.h"
+#include "base/primitives.h"
 
 
 namespace SunLight {
@@ -50,7 +34,9 @@ namespace SunLight {
             m_nTileSize        = 0;
             m_nCenterTileIndex = 0;
             m_AnimationMode    = TEXTURE_ANIMATION_MODE_MANUAL;
-            std :: memset( &m_Texture, 0, sizeof( m_Texture ) );
+            m_hTexture         = nullptr;
+            m_nTextureWidth    = 0;
+            m_nTextureHeight   = 0;
             SetColor( WHITE_COLOR );
             Reset();
             m_bIsResetting = false;
@@ -72,13 +58,15 @@ namespace SunLight {
 
             SunLight :: TileMap :: stDimension2D& dimension = GetDimension2D();
 
-            m_Texture = ::LoadTexture( strTextureFile.c_str() );
+            m_hTexture = SunLight :: Engines :: EngineFactory :: GetEngine().LoadTexture( strTextureFile.c_str(),
+                                                                                          m_nTextureWidth,
+                                                                                          m_nTextureHeight );
 
-            if( m_Texture.id > 0 )  {
+            if( m_hTexture != nullptr )  {
                 if( ( dimension.size.nHeight == 0 ) &&
                     ( dimension.size.nHeight == 0 )  ) {
-                    dimension.size.nHeight = m_Texture.height;
-                    dimension.size.nWidth  = m_Texture.width;
+                    dimension.size.nHeight = m_nTextureHeight;
+                    dimension.size.nWidth  = m_nTextureWidth;
                 }
 
                 return true;
@@ -92,9 +80,9 @@ namespace SunLight {
          */
         bool TextureCanvas :: Unload( void )  {
 
-            if( m_Texture.id > 0 )  {
-                ::UnloadTexture( m_Texture );
-                m_Texture.id = 0;
+            if( m_hTexture != nullptr )  {
+                SunLight :: Engines :: EngineFactory :: GetEngine().UnloadTexture( m_hTexture );
+                m_hTexture = nullptr;
                 return true;
             }
 
@@ -138,7 +126,7 @@ namespace SunLight {
          */
         void TextureCanvas :: SetActiveTileIndex( unsigned int nActiveTileIndex )  {
 
-            if( m_Texture.width >= ( int ) ( m_nTileSize * nActiveTileIndex ) )
+            if( m_nTextureWidth >= ( int ) ( m_nTileSize * nActiveTileIndex ) )
                 m_nActiveTileIndex = nActiveTileIndex;
         }
 
@@ -159,7 +147,7 @@ namespace SunLight {
          */
         void TextureCanvas :: SetCenterTileIndex( unsigned int nTileIndex )  {
 
-            if( m_Texture.width >= ( int ) ( m_nTileSize * nTileIndex ) )
+            if( m_nTextureWidth >= ( int ) ( m_nTileSize * nTileIndex ) )
                 m_nCenterTileIndex = nTileIndex;
         }
 
@@ -227,13 +215,13 @@ namespace SunLight {
 
                     switch( m_AnimationMode )  {
                         case TEXTURE_ANIMATION_MODE_AUTOMATIC_CIRCULAR :
-                            m_nCurrentTile = ( m_nCurrentTile >= m_Texture.width ? 0 :
+                            m_nCurrentTile = ( m_nCurrentTile >= m_nTextureWidth ? 0 :
                                             m_nCurrentTile + m_nTileSize );
                             break;
                         case TEXTURE_ANIMATION_MODE_AUTOMATIC_RIGHT_LEFT :
                             if( m_nTileSize != 0 )  {
                                 if( m_bAnimationRight )  {
-                                    if( m_nActiveTileIndex < ( m_Texture.width / m_nTileSize ) )  {
+                                    if( m_nActiveTileIndex < ( m_nTextureWidth / m_nTileSize ) )  {
                                         m_nCurrentTile = ( m_nTileSize * m_nActiveTileIndex );
                                         m_nActiveTileIndex++;
                                     }
@@ -262,7 +250,7 @@ namespace SunLight {
                         break;
                         case TEXTURE_ANIMATION_MODE_ANIMATE_RIGHT:
                             if( m_nTileSize != 0 )  {
-                                if( m_nActiveTileIndex < ( m_Texture.width / m_nTileSize ) )  {
+                                if( m_nActiveTileIndex < ( m_nTextureWidth / m_nTileSize ) )  {
                                     m_nCurrentTile = ( m_nTileSize * m_nActiveTileIndex );
                                     m_nActiveTileIndex++;
                                 }
@@ -296,24 +284,22 @@ namespace SunLight {
                             break;
                     }
 
-                    __DEFAULT_ENGINE :: DrawTextureTiled( m_Texture,
-                                                          Rectangle { ( float ) m_nCurrentTile + nClipX,
+                    SunLight :: Engines :: EngineFactory :: GetEngine().DrawTextureTiled(
+                                                          m_hTexture,
+                                                          SunLight :: Base :: stRectangle { ( float ) m_nCurrentTile + nClipX,
                                                                       ( float ) nClipY,
                                                                       ( float ) ( m_nTileSize > 0 ?
                                                                                   m_nTileSize :
-                                                                                  m_Texture.width ),
-                                                                      ( float ) m_Texture.height },
-                                                          Rectangle { ( float ) clip.pos.x,
+                                                                                  m_nTextureWidth ),
+                                                                      ( float ) m_nTextureHeight },
+                                                          SunLight :: Base :: stRectangle { ( float ) clip.pos.x,
                                                                       ( float ) clip.pos.y,
                                                                       ( float ) clip.size.nWidth,
                                                                       ( float ) clip.size.nHeight },
-                                                          Vector2   { 0.0, 0.0 },
+                                                          SunLight :: Base :: stVector2D { 0.0, 0.0 },
                                                           0.0, // TODO: Rotation
                                                           fZoomFactor,
-                                                          Color      { color.nRed,
-                                                                       color.nGreen,
-                                                                       color.nBlue,
-                                                                       color.nAlpha } );
+                                                          color );
                 }
             }
 

--- a/src/canvas/texturecanvas.h
+++ b/src/canvas/texturecanvas.h
@@ -21,9 +21,9 @@
 #ifndef __TEXTURECANVAS_H__
 #define __TEXTURECANVAS_H__
 
-#include <raylib.h>
 #include <string>
 #include "canvas/canvas.h"
+#include "base/primitives.h"
 
 
 namespace SunLight {
@@ -47,7 +47,9 @@ namespace SunLight {
          */
         class TextureCanvas : public SunLight :: Canvas :: Canvas  {
 
-            Texture2D                   m_Texture;
+            SunLight :: Base :: TextureHandle m_hTexture;
+            int                         m_nTextureWidth;
+            int                         m_nTextureHeight;
             unsigned int                m_nTileSize;
             unsigned int                m_nActiveTileIndex;
             unsigned int                m_nCenterTileIndex;

--- a/src/collision/collisionmanager.cpp
+++ b/src/collision/collisionmanager.cpp
@@ -61,7 +61,7 @@ namespace SunLight {
             m_pParent = pParent;
 
             for( int nCount = 0; nCount < m_ColliderLayerList.size(); nCount++)  {
-                m_ColliderLayerList[nCount] = new ColliderList();
+                m_ColliderLayerList[nCount] = std :: make_unique<ColliderList>();
             }
         }
 
@@ -100,7 +100,7 @@ namespace SunLight {
                                                  SunLight :: Collision :: Collider *pCollider )  {
 
             if( nColliderLayerId < m_ColliderLayerList.size() )  {
-                ColliderList   *pColliderList = m_ColliderLayerList[nColliderLayerId];
+                ColliderList   *pColliderList = m_ColliderLayerList[nColliderLayerId].get();
                 ColliderList :: iterator itItem = std :: find( pColliderList -> begin(),
                                                             pColliderList -> end(),
                                                             pCollider );
@@ -123,7 +123,7 @@ namespace SunLight {
 
             if( nColliderLayerId < m_ColliderLayerList.size() )  {
                 if( nColliderLayerId < 0 )  {
-                    for( ColliderList *pColliderList : m_ColliderLayerList )  {
+                    for( auto& pColliderList : m_ColliderLayerList )  {
                         pColliderList -> clear();
                     }
                 }
@@ -143,16 +143,11 @@ namespace SunLight {
         void CollisionManager :: Clear( void )  {
 
             for( int nCount = 0; nCount < m_ColliderLayerList.size(); nCount++)  {
-                delete m_ColliderLayerList[nCount];
+                m_ColliderLayerList[nCount].reset();
             }
 
-            for( ColliderPair *pPair : m_ColliderToColliderRuleList )  {
-                delete pPair;
-            }
-
-            for( ColliderTileLayerPair *pPair : m_ColliderToTileLayerRuleList )  {
-                delete pPair;
-            }
+            m_ColliderToColliderRuleList.clear();
+            m_ColliderToTileLayerRuleList.clear();
         }
 
         /**
@@ -168,14 +163,14 @@ namespace SunLight {
                                                             int nSecondColliderLayerId )  {
 
             ColliderLayerList& colliderLayerListRef = m_ColliderLayerList;
-            ColliderToColliderRuleList :: iterator itItem = std :: find_if( m_ColliderToColliderRuleList.begin(), 
-                                                                            m_ColliderToColliderRuleList.end(), 
-                                                                            [nFirstColliderLayerId, 
-                                                                             nSecondColliderLayerId, 
-                                                                             colliderLayerListRef]( const ColliderPair* pPair ) {
-                                
-                                ColliderList *pFirst  = colliderLayerListRef[nFirstColliderLayerId];
-                                ColliderList *pSecond = colliderLayerListRef[nSecondColliderLayerId];
+            ColliderToColliderRuleList :: iterator itItem = std :: find_if( m_ColliderToColliderRuleList.begin(),
+                                                                            m_ColliderToColliderRuleList.end(),
+                                                                            [nFirstColliderLayerId,
+                                                                             nSecondColliderLayerId,
+                                                                             &colliderLayerListRef]( const std :: unique_ptr<ColliderPair>& pPair ) {
+
+                                ColliderList *pFirst  = colliderLayerListRef[nFirstColliderLayerId].get();
+                                ColliderList *pSecond = colliderLayerListRef[nSecondColliderLayerId].get();
 
                                 return ( ( pPair -> first == pFirst ) && ( pPair -> second == pSecond ) );
                             } );
@@ -184,12 +179,12 @@ namespace SunLight {
                 ( nFirstColliderLayerId < m_ColliderLayerList.size() ) &&
                 ( nFirstColliderLayerId < m_ColliderLayerList.size() ) )  {
 
-                ColliderPair  *pPair = new ColliderPair();
+                std :: unique_ptr<ColliderPair>  pPair = std :: make_unique<ColliderPair>();
 
-                pPair -> first  = m_ColliderLayerList[nFirstColliderLayerId];
-                pPair -> second = m_ColliderLayerList[nSecondColliderLayerId];
+                pPair -> first  = m_ColliderLayerList[nFirstColliderLayerId].get();
+                pPair -> second = m_ColliderLayerList[nSecondColliderLayerId].get();
 
-                m_ColliderToColliderRuleList.push_back( pPair );
+                m_ColliderToColliderRuleList.push_back( std :: move( pPair ) );
 
                 return true;
             }
@@ -213,12 +208,12 @@ namespace SunLight {
             if( ( nColliderLayerId < m_ColliderLayerList.size() ) &&
                 m_pParent -> GetLayer( nTileLayerId, layer ) )  {
 
-                ColliderTileLayerPair  *pPair = new ColliderTileLayerPair();
+                std :: unique_ptr<ColliderTileLayerPair>  pPair = std :: make_unique<ColliderTileLayerPair>();
 
-                pPair -> first  = m_ColliderLayerList[nColliderLayerId];
+                pPair -> first  = m_ColliderLayerList[nColliderLayerId].get();
                 pPair -> second = nTileLayerId;
 
-                m_ColliderToTileLayerRuleList.push_back( pPair );
+                m_ColliderToTileLayerRuleList.push_back( std :: move( pPair ) );
 
                 return true;
             }
@@ -246,7 +241,7 @@ namespace SunLight {
             /*
             * Check collisions between colliders only.
             */
-            for( ColliderPair *pPair : m_ColliderToColliderRuleList )  {
+            for( auto& pPair : m_ColliderToColliderRuleList )  {
                 for( Collider *pFirst : *pPair -> first )  {
                     for( Collider *pSecond : *pPair -> second )  {
                         if( pFirst -> Hit( pSecond -> GetDimension2D() ) )  {
@@ -260,7 +255,7 @@ namespace SunLight {
             * Check collisions between colliders against static
             * layer objects defined as collision on layer map.
             */
-            for( ColliderTileLayerPair *pPair : m_ColliderToTileLayerRuleList )  {
+            for( auto& pPair : m_ColliderToTileLayerRuleList )  {
                 for( Collider *pFirst : *pPair -> first )  {
                     SunLight :: TileMap :: stTile      tile;
                     SunLight :: TileMap :: stLayer     layer;

--- a/src/collision/collisionmanager.h
+++ b/src/collision/collisionmanager.h
@@ -23,6 +23,7 @@
 
 #include <queue>
 #include <array>
+#include <memory>
 #include "collision/icollisionmanager.h"
 #include "tilemap/itilemap.h"
 
@@ -39,12 +40,12 @@ namespace SunLight {
         class CollisionManager : public SunLight :: Base :: Object, public ICollisionManager  {
 
             typedef std :: deque<Collider*>  ColliderList;
-            typedef std :: array<ColliderList*, MAX_COLLIDER_LAYERS> ColliderLayerList;
+            typedef std :: array<std :: unique_ptr<ColliderList>, MAX_COLLIDER_LAYERS> ColliderLayerList;
             typedef std :: deque<ICollisionListener*> CollisionListenerList;
             typedef std :: pair<ColliderList*, ColliderList*> ColliderPair;
-            typedef std :: deque<ColliderPair*> ColliderToColliderRuleList;
+            typedef std :: deque<std :: unique_ptr<ColliderPair>> ColliderToColliderRuleList;
             typedef std :: pair<ColliderList*, int> ColliderTileLayerPair;
-            typedef std :: deque<ColliderTileLayerPair*> ColliderToTileLayerRuleList;
+            typedef std :: deque<std :: unique_ptr<ColliderTileLayerPair>> ColliderToTileLayerRuleList;
 
             SunLight :: TileMap :: ITileMap   *m_pParent;
             ColliderLayerList                 m_ColliderLayerList;

--- a/src/engines/enginefactory.cpp
+++ b/src/engines/enginefactory.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
- * 
+ *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages
  * arising from the use of this software.
@@ -18,30 +18,33 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "world.h"
-#include <string>
-#include <cstdio>
+#include "enginefactory.h"
+
+#ifndef DEFAULT_ENGINE
+    #error "Unexpected value of DEFAULT_ENGINE"
+#endif
+
+#if DEFAULT_ENGINE == 1    /* USES RAYLIB */
+    #include "engines/raylib/raylibengine.h"
+
+    #define __DEFAULT_ENGINE  SunLight :: Engines :: Raylib :: RaylibEngine
+#else
+    #error "Unknown value of DEFAULT_ENGINE"
+#endif
 
 
-int main( int argc, char **argv ) {
-    std :: string   strBasePath;
-    World           *pWorld;
-    bool            bRet;
+namespace SunLight {
+    namespace Engines  {
 
-    // Check command line arguments
-    if( argc < 2 )  {
-        fprintf( stderr, "Invalid command line arguments\n" );
-        return EXIT_FAILURE;
+        /**
+         * @brief Get the single @see IEngine instance for the backend
+         * selected at build time.
+         */
+        IEngine& EngineFactory :: GetEngine( void )  {
+
+            static __DEFAULT_ENGINE engine;
+
+            return engine;
+        }
     }
-
-    strBasePath = argv[1];  
-    pWorld = new World( strBasePath );
-    bRet = pWorld -> Run();
-    delete pWorld;
-
-    if( !bRet ){
-        return EXIT_FAILURE;
-    }
-
-    return EXIT_SUCCESS;
 }

--- a/src/engines/enginefactory.h
+++ b/src/engines/enginefactory.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
- * 
+ *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages
  * arising from the use of this software.
@@ -18,30 +18,28 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "world.h"
-#include <string>
-#include <cstdio>
+#ifndef __ENGINEFACTORY_H__
+#define __ENGINEFACTORY_H__
+
+#include "engines/iengine.h"
 
 
-int main( int argc, char **argv ) {
-    std :: string   strBasePath;
-    World           *pWorld;
-    bool            bRet;
+namespace SunLight {
+    namespace Engines  {
 
-    // Check command line arguments
-    if( argc < 2 )  {
-        fprintf( stderr, "Invalid command line arguments\n" );
-        return EXIT_FAILURE;
+        /**
+         * @brief Rendering engine access point used to retrieve the
+         * @see IEngine implementation selected at build time (DEFAULT_ENGINE).
+         * This is the only place in the codebase that needs to know which
+         * concrete backend is compiled in.
+         */
+        class EngineFactory  {
+
+            public:
+
+            static IEngine& GetEngine( void );
+        };
     }
-
-    strBasePath = argv[1];  
-    pWorld = new World( strBasePath );
-    bRet = pWorld -> Run();
-    delete pWorld;
-
-    if( !bRet ){
-        return EXIT_FAILURE;
-    }
-
-    return EXIT_SUCCESS;
 }
+
+#endif  /* __ENGINEFACTORY_H__ */

--- a/src/engines/iengine.h
+++ b/src/engines/iengine.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef __IENGINE_H__
+#define __IENGINE_H__
+
+#include "base/color.h"
+#include "base/primitives.h"
+
+
+namespace SunLight  {
+    namespace Engines  {
+
+        /**
+         * @brief Backend rendering engine generic interface.
+         * Every graphics backend (raylib, SDL, ...) implements this using
+         * its own native types internally, exposing only SunLight native
+         * primitives here.
+         */
+        class IEngine  {
+
+            public:
+
+            virtual ~IEngine( void )  {}
+
+            virtual SunLight :: Base :: TextureHandle LoadTexture( const char *szFileName,
+                                                                    int& nWidth,
+                                                                    int& nHeight ) = 0;
+            virtual void UnloadTexture( SunLight :: Base :: TextureHandle hTexture ) = 0;
+
+            virtual void SetPixel( int nPosX, int nPosY, SunLight :: Base :: stColor color ) = 0;
+
+            virtual void DrawTexture( SunLight :: Base :: TextureHandle hTexture,
+                                      int nPosX,
+                                      int nPosY,
+                                      SunLight :: Base :: stColor tint ) = 0;
+
+            virtual void DrawTextureTiled( SunLight :: Base :: TextureHandle hTexture,
+                                           SunLight :: Base :: stRectangle source,
+                                           SunLight :: Base :: stRectangle dest,
+                                           SunLight :: Base :: stVector2D origin,
+                                           float rotation,
+                                           float scale,
+                                           SunLight :: Base :: stColor tint ) = 0;
+        };
+    }
+}
+
+#endif  /* __IENGINE_H__ */

--- a/src/engines/raylib/raylibengine.cpp
+++ b/src/engines/raylib/raylibengine.cpp
@@ -25,26 +25,32 @@ namespace SunLight  {
         namespace Raylib  {
 
             /**
-             * @brief Draw part of a texture (defined by a rectangle) with rotation and scale tiled into dest 
+             * @brief Draw part of a texture (defined by a rectangle) with rotation and scale tiled into dest
              * This routines is planned to be removed after raylib 4.2.0 and was moved to a samples project directory
              * found at https://github.com/raysan5/raylib/blob/master/examples/textures/textures_draw_tiled.c
-             * 
-             * @param texture 
-             * @param source 
-             * @param dest 
-             * @param origin 
-             * @param rotation 
-             * @param scale 
-             * @param tint 
+             *
+             * @param hTexture
+             * @param sourceIn
+             * @param destIn
+             * @param originIn
+             * @param rotation
+             * @param scale
+             * @param tintIn
              */
-            void RaylibEngine :: DrawTextureTiled( Texture2D texture, 
-                                                   Rectangle source, 
-                                                   Rectangle dest, 
-                                                   Vector2 origin, 
-                                                   float rotation, 
-                                                   float scale, 
-                                                   Color tint )  {
-                                    
+            void RaylibEngine :: DrawTextureTiled( SunLight :: Base :: TextureHandle hTexture,
+                                                   SunLight :: Base :: stRectangle sourceIn,
+                                                   SunLight :: Base :: stRectangle destIn,
+                                                   SunLight :: Base :: stVector2D originIn,
+                                                   float rotation,
+                                                   float scale,
+                                                   SunLight :: Base :: stColor tintIn )  {
+
+                Texture2D  texture = *reinterpret_cast<Texture2D*>( hTexture );
+                Rectangle  source  { sourceIn.x, sourceIn.y, sourceIn.width, sourceIn.height };
+                Rectangle  dest    { destIn.x, destIn.y, destIn.width, destIn.height };
+                Vector2    origin  { originIn.x, originIn.y };
+                Color      tint    { tintIn.nRed, tintIn.nGreen, tintIn.nBlue, tintIn.nAlpha };
+
                 if ((texture.id <= 0) || (scale <= 0.0f)) return;  // Wanna see a infinite loop?!...just delete this line!
                 if ((source.width == 0) || (source.height == 0)) return;
 
@@ -221,8 +227,66 @@ namespace SunLight  {
              * @param nPosY The Y coordinate to plot pixel;
              * @param color Color of pixel;
              */
-            void RaylibEngine :: SetPixel( int nPosX, int nPosY, Color color )  {
-                ::DrawPixel( nPosX, nPosY, color );
+            void RaylibEngine :: SetPixel( int nPosX, int nPosY, SunLight :: Base :: stColor color )  {
+                ::DrawPixel( nPosX, nPosY, Color{ color.nRed, color.nGreen, color.nBlue, color.nAlpha } );
+            }
+
+            /**
+             * @brief Load a texture from disk.
+             * @param szFileName Texture file name to load;
+             * @param nWidth Output parameter receiving the loaded texture width;
+             * @param nHeight Output parameter receiving the loaded texture height;
+             * @return An opaque handle to the loaded texture, or nullptr on failure;
+             */
+            SunLight :: Base :: TextureHandle RaylibEngine :: LoadTexture( const char *szFileName,
+                                                                            int& nWidth,
+                                                                            int& nHeight )  {
+
+                Texture2D *pTexture = new Texture2D;
+
+                *pTexture = ::LoadTexture( szFileName );
+
+                if( pTexture -> id <= 0 )  {
+                    delete pTexture;
+                    nWidth  = 0;
+                    nHeight = 0;
+
+                    return nullptr;
+                }
+
+                nWidth  = pTexture -> width;
+                nHeight = pTexture -> height;
+
+                return pTexture;
+            }
+
+            /**
+             * @brief Unload a texture previously loaded by @see LoadTexture.
+             * @param hTexture The texture handle to unload;
+             */
+            void RaylibEngine :: UnloadTexture( SunLight :: Base :: TextureHandle hTexture )  {
+
+                Texture2D *pTexture = reinterpret_cast<Texture2D*>( hTexture );
+
+                ::UnloadTexture( *pTexture );
+                delete pTexture;
+            }
+
+            /**
+             * @brief Draw a texture at the specified position.
+             * @param hTexture The texture handle to draw;
+             * @param nPosX X coordinate to draw texture;
+             * @param nPosY Y coordinate to draw texture;
+             * @param tint Color tint applied to texture;
+             */
+            void RaylibEngine :: DrawTexture( SunLight :: Base :: TextureHandle hTexture,
+                                              int nPosX,
+                                              int nPosY,
+                                              SunLight :: Base :: stColor tint )  {
+
+                Texture2D *pTexture = reinterpret_cast<Texture2D*>( hTexture );
+
+                ::DrawTexture( *pTexture, nPosX, nPosY, Color{ tint.nRed, tint.nGreen, tint.nBlue, tint.nAlpha } );
             }
         }
     }

--- a/src/engines/raylib/raylibengine.h
+++ b/src/engines/raylib/raylibengine.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
- * 
+ *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages
  * arising from the use of this software.
@@ -22,6 +22,7 @@
 #define __RAYLIBENGINE_H__
 
 #include "raylib.h"
+#include "engines/iengine.h"
 
 namespace SunLight  {
     namespace Engines  {
@@ -29,24 +30,34 @@ namespace SunLight  {
 
             /**
              * @brief Raylib engine provider implementation.
-             * All specific raylib calls are implemented here. 
+             * All specific raylib calls are implemented here.
              */
-            class RaylibEngine  {
+            class RaylibEngine : public SunLight :: Engines :: IEngine  {
 
                 public:
 
-                static void DrawTextureTiled( Texture2D texture,
-                                              Rectangle source, 
-                                              Rectangle dest, 
-                                              Vector2 origin,
-                                              float rotation, 
-                                              float scale, 
-                                              Color tint);
-                static void SetPixel( int nPosX, int nPosY, Color color );
+                SunLight :: Base :: TextureHandle LoadTexture( const char *szFileName,
+                                                                int& nWidth,
+                                                                int& nHeight ) override;
+                void UnloadTexture( SunLight :: Base :: TextureHandle hTexture ) override;
+
+                void SetPixel( int nPosX, int nPosY, SunLight :: Base :: stColor color ) override;
+
+                void DrawTexture( SunLight :: Base :: TextureHandle hTexture,
+                                   int nPosX,
+                                   int nPosY,
+                                   SunLight :: Base :: stColor tint ) override;
+
+                void DrawTextureTiled( SunLight :: Base :: TextureHandle hTexture,
+                                       SunLight :: Base :: stRectangle source,
+                                       SunLight :: Base :: stRectangle dest,
+                                       SunLight :: Base :: stVector2D origin,
+                                       float rotation,
+                                       float scale,
+                                       SunLight :: Base :: stColor tint ) override;
             };
         }
     }
 }
 #endif  /* __RAYLIBENGINE_H__ */
-
 

--- a/src/input/inputhandlerfactory.h
+++ b/src/input/inputhandlerfactory.h
@@ -21,6 +21,7 @@
 #ifndef __IINPUTHANDLERFACTORY_H__
 #define __IINPUTHANDLERFACTORY_H__
 
+#include <memory>
 #include "iinputhandler.h"
 
 
@@ -29,14 +30,14 @@ namespace SunLight {
 
         /**
          * @brief Input handler class factory used to create
-         * @see IInputHandler objects based on configured 
+         * @see IInputHandler objects based on configured
          * backend renderer engine.
          */
         class InputHandlerFactory  {
 
             public:
 
-            static IInputHandler* CreateInputHandler( void );
+            static std :: unique_ptr<IInputHandler> CreateInputHandler( void );
         };
      }
 }

--- a/src/input/inputhandlrfactory.cpp
+++ b/src/input/inputhandlrfactory.cpp
@@ -40,11 +40,9 @@ namespace SunLight {
          * 
          * @return Pointer to created IInputHandler; 
          */
-        IInputHandler* InputHandlerFactory :: CreateInputHandler( void )  {
+        std :: unique_ptr<IInputHandler> InputHandlerFactory :: CreateInputHandler( void )  {
 
-            IInputHandler* pInputHandler = new __DEFAULT_INPUT_HANDLER();
-
-            return pInputHandler;
-        } 
+            return std :: make_unique<__DEFAULT_INPUT_HANDLER>();
+        }
     }
 }

--- a/src/renderer/tilemaprenderer.cpp
+++ b/src/renderer/tilemaprenderer.cpp
@@ -609,12 +609,14 @@ namespace SunLight {
                             tmx_tileset_list           *pTilesetList;
 
                             if( !pAnimInfo )  {
-                                pAnimInfo = new __stTileAnimInfo;
-                                memset( pAnimInfo, 0, sizeof( __stTileAnimInfo ) );
-                                pAnimInfo -> nMillis   = nMillis;
-                                pAnimInfo -> pNextTile = pTile;
+                                std :: unique_ptr<__stTileAnimInfo>  pOwnedAnimInfo = std :: make_unique<__stTileAnimInfo>();
+
+                                memset( pOwnedAnimInfo.get(), 0, sizeof( __stTileAnimInfo ) );
+                                pOwnedAnimInfo -> nMillis   = nMillis;
+                                pOwnedAnimInfo -> pNextTile = pTile;
+                                pAnimInfo = pOwnedAnimInfo.get();
                                 pTile -> user_data.pointer = pAnimInfo;
-                                m_AnimInfoList.push_back( pAnimInfo );
+                                m_AnimInfoList.push_back( std :: move( pOwnedAnimInfo ) );
                             }
 
                             if( pAnimInfo -> nMillis <= nMillis )  {
@@ -1083,19 +1085,8 @@ namespace SunLight {
 
             UnloadMap();
             m_TileMapListenerList.clear();
-
-            for( InputEventHandlerList :: iterator itItem = m_KeyInputEventHandlerList.begin(); itItem != m_KeyInputEventHandlerList.end(); itItem++ )  {
-                delete  ( * itItem );
-            }
-
-            for( InputEventHandlerList :: iterator itItem = m_GPadInputEventHandlerList.begin(); itItem != m_GPadInputEventHandlerList.end(); itItem++ )  {
-                delete  ( * itItem );
-            }
-
             m_KeyInputEventHandlerList.clear();
             m_GPadInputEventHandlerList.clear();
-
-            delete m_pInputHandler;
         }
 
         /**
@@ -1222,11 +1213,11 @@ namespace SunLight {
                                                         SunLight :: Input :: INPUT_EVENT_HANDLER handler )  {
 
             if( evt != SunLight :: Input :: KeyboardKey :: KEY_NULL )  {
-                __stInputEventData *pEvtData = new __stInputEventData;
+                std :: unique_ptr<__stInputEventData>  pEvtData = std :: make_unique<__stInputEventData>();
 
                 pEvtData -> nEvent   = evt;
                 pEvtData -> pHandler = handler;
-                m_KeyInputEventHandlerList.push_back( pEvtData );
+                m_KeyInputEventHandlerList.push_back( std :: move( pEvtData ) );
             }
             else  {
                 m_pNullInputEventHandler = handler;
@@ -1242,11 +1233,11 @@ namespace SunLight {
         void TileMapRenderer :: SetUserGamePadEventHandler( SunLight :: Input :: GamepadButton evt, 
                                                             SunLight :: Input :: INPUT_EVENT_HANDLER handler )  {
 
-            __stInputEventData *pEvtData = new __stInputEventData;
+            std :: unique_ptr<__stInputEventData>  pEvtData = std :: make_unique<__stInputEventData>();
 
             pEvtData -> nEvent   = evt;
             pEvtData -> pHandler = handler;
-            m_GPadInputEventHandlerList.push_back( pEvtData );
+            m_GPadInputEventHandlerList.push_back( std :: move( pEvtData ) );
         }
 
         /**
@@ -1579,12 +1570,7 @@ namespace SunLight {
                 /*
                 * Release all allocated animations data structure.
                 */
-                __AnimInfoList :: iterator itItem = m_AnimInfoList.begin();
-
-                while( itItem != m_AnimInfoList.end() )  {
-                    delete *itItem;
-                    itItem = m_AnimInfoList.erase( itItem );
-                }
+                m_AnimInfoList.clear();
 
                 m_pTmxMap    = NULL;
                 m_nMapWidth  = 0;

--- a/src/renderer/tilemaprenderer.cpp
+++ b/src/renderer/tilemaprenderer.cpp
@@ -18,24 +18,11 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef DEFAULT_ENGINE
-    #error "Unexpected value of DEFAULT_ENGINE"
-#endif
-
-/*
- * In the future a better abstract way to handle raylib will be
- * implemented and the method below will be changed.
- */
-#if DEFAULT_ENGINE == 1    /* USES RAYLIB */
-    #include "engines/raylib/raylibengine.h"
-    
-    #define __DEFAULT_ENGINE         RaylibEngine
-#else
-    #error "Unknown value of DEFAULT_ENGINE"
-#endif
-
+#include "engines/enginefactory.h"
+#include "base/primitives.h"
 #include "input/inputhandlerfactory.h"
 #include "tilemaprenderer.h"
+#include <raylib.h>
 #include <memory.h>
 #include <cstring>
 #include <chrono>
@@ -53,7 +40,7 @@
 #define __DEFAULT_RESIZEABLE_STATUS     false
 #define __DEFAULT_DRAW_FPS_STATUS       false
 #define __DEFAULT_VIEW_CONTROL_MODE     VIEW_CONTROL_MODE_ACTIVE
-#define __DEFAULT_EXIT_KEY              KEY_ESCAPE
+#define __DEFAULT_EXIT_KEY              SunLight :: Input :: KEY_ESCAPE
 #define __DEFAULT_WINDOW_BK_COLOR       0xFF000000
 
 
@@ -63,7 +50,6 @@
 #define __MAX_OPACITY_LEVEL            0xFF
 
 using namespace std :: chrono;
-using namespace SunLight :: Engines :: Raylib;
 
 
 namespace SunLight {
@@ -81,11 +67,9 @@ namespace SunLight {
          */
         void* TileMapRenderer :: TextureLoaderCallback( const char *szFileName )  {
 
-            Texture2D *pTexture = new Texture2D;
+            int nWidth, nHeight;
 
-            *pTexture = ::LoadTexture( szFileName );
-
-            return pTexture;
+            return SunLight :: Engines :: EngineFactory :: GetEngine().LoadTexture( szFileName, nWidth, nHeight );
         }
 
         /**
@@ -94,11 +78,7 @@ namespace SunLight {
          */
         void TileMapRenderer :: TextureFreeCallback( void *pTexture )  {
 
-            Texture2D    *pTexture2D = ( Texture2D * ) pTexture;
-
-            ::UnloadTexture( *pTexture2D );
-
-            delete pTexture2D;
+            SunLight :: Engines :: EngineFactory :: GetEngine().UnloadTexture( pTexture );
         }
 
         /**
@@ -152,11 +132,11 @@ namespace SunLight {
         /**
          * Convert integer color representation to @link Color object;
          */
-        Color TileMapRenderer :: IntToColor( uint32_t color ) {
+        SunLight :: Base :: stColor TileMapRenderer :: IntToColor( uint32_t color ) {
 
             tmx_col_bytes res = ::tmx_col_to_bytes( color );
 
-            return *( ( Color * ) &res );
+            return *( ( SunLight :: Base :: stColor * ) &res );
         }
 
         /**
@@ -165,13 +145,13 @@ namespace SunLight {
          * @param nCoordY The Y coordinate to plot pixel;
          * @param color Color of pixel;
          */
-        void TileMapRenderer :: SetPixel( int nCoordX, int nCoordY, Color color )  {
+        void TileMapRenderer :: SetPixel( int nCoordX, int nCoordY, SunLight :: Base :: stColor color )  {
 
             SunLight :: TileMap :: stDimension2D& vp = GetViewport().GetDimension2D();
 
             if( ( nCoordX > vp.pos.x ) && ( nCoordX < vp.size. nWidth) &&
                 ( nCoordY  > vp.pos. y ) && ( nCoordY < vp.size.nHeight ) ) {
-                __DEFAULT_ENGINE :: SetPixel( nCoordX, nCoordY, color );
+                SunLight :: Engines :: EngineFactory :: GetEngine().SetPixel( nCoordX, nCoordY, color );
             }
         }
 
@@ -188,7 +168,7 @@ namespace SunLight {
                                                  double fCoordY,
                                                  double fRadiusX,
                                                  double fRadiusY,
-                                                 Color color ) {
+                                                 SunLight :: Base :: stColor color ) {
 
             double          dx, dy;
             double          d1, d2;
@@ -284,7 +264,7 @@ namespace SunLight {
                                                int nY0,
                                                int nX1,
                                                int nY1,
-                                               Color color )  {
+                                               SunLight :: Base :: stColor color )  {
 
             int             nE2; /* error value e_xy */
             int             nDx  = std :: abs( nX1 - nX0 );
@@ -325,7 +305,7 @@ namespace SunLight {
                                               double fOffset_y,
                                               double **fPoints,
                                               int nPointsCount,
-                                              Color color ) {
+                                              SunLight :: Base :: stColor color ) {
 
             SunLight :: Base :: stZoomProperties&  zp = GetViewport().GetZoomProperties();
             SunLight :: TileMap :: stDimension2D&  vp = GetViewport().GetDimension2D();
@@ -353,7 +333,7 @@ namespace SunLight {
                                          double fOffset_y,
                                          double **fPoints,
                                          int nPointsCount,
-                                         Color color ) {
+                                         SunLight :: Base :: stColor color ) {
 
             SunLight :: TileMap :: stDimension2D&  vp = GetViewport().GetDimension2D();
 
@@ -391,7 +371,7 @@ namespace SunLight {
                                                double fOffset_y,
                                                double fWidth,
                                                double fHeight,
-                                               Color color )  {
+                                               SunLight :: Base :: stColor color )  {
 
             SunLight :: TileMap :: stDimension2D&  vp          = GetViewport().GetDimension2D();
             SunLight :: Base :: stZoomProperties&  zp          = GetViewport().GetZoomProperties();
@@ -444,7 +424,7 @@ namespace SunLight {
                                              double fOffset_y,
                                              double fWidth,
                                              double fHeight,
-                                             Color color )  {
+                                             SunLight :: Base :: stColor color )  {
 
             SunLight :: TileMap :: stDimension2D&  vp = GetViewport().GetDimension2D();
             SunLight :: Base :: stZoomProperties&  zp = GetViewport().GetZoomProperties();
@@ -474,7 +454,7 @@ namespace SunLight {
          * @param uDestY destination Y coordinate on texture;
          * @param opacity opacity level to be applied on texture;
          */
-        void TileMapRenderer :: DrawTile( void *pImage,
+        void TileMapRenderer :: DrawTile( SunLight :: Base :: TextureHandle pImage,
                                           int32_t nSourceX,
                                           int32_t nSourceY,
                                           int32_t nSourceW,
@@ -485,7 +465,6 @@ namespace SunLight {
 
             SunLight :: TileMap :: stDimension2D  clip;
             SunLight :: Base :: Viewport&         vp        = GetViewport();
-            Texture2D                             *pTexture = ( Texture2D * ) pImage;
             unsigned char                         op        = ( uint8_t ) ( 0xFF * fOpacity );
             SunLight :: TileMap :: stDimension2D  dm        =  { { ( int ) ( nDestX + m_CameraPos.x ),
                                                                  ( int ) ( nDestY + m_CameraPos.y ) },
@@ -504,19 +483,19 @@ namespace SunLight {
                                                                                                 fZoomFactor ) -
                                                                                   dm.size.nHeight ) : nSourceY );
 
-                __DEFAULT_ENGINE :: DrawTextureTiled( *pTexture,
-                                                      Rectangle  { ( float ) nClipX,
+                SunLight :: Engines :: EngineFactory :: GetEngine().DrawTextureTiled( pImage,
+                                                      SunLight :: Base :: stRectangle  { ( float ) nClipX,
                                                                    ( float ) nClipY,
                                                                    ( float ) nSourceW,
                                                                    ( float ) nSourceH },
-                                                      Rectangle  { ( float ) clip.pos.x,
+                                                      SunLight :: Base :: stRectangle  { ( float ) clip.pos.x,
                                                                    ( float ) clip.pos.y,
                                                                    ( float ) clip.size.nWidth,
                                                                    ( float ) clip.size.nHeight },
-                                                      Vector2  { 0, 0 },
+                                                      SunLight :: Base :: stVector2D  { 0, 0 },
                                                       0.0f,
                                                       fZoomFactor,
-                                                      Color  { 0xFF, 0xFF, 0xFF, op } );
+                                                      SunLight :: Base :: stColor  { 0xFF, 0xFF, 0xFF, op } );
             }
         }
 
@@ -527,7 +506,7 @@ namespace SunLight {
         void TileMapRenderer :: DrawObjects( tmx_layer *pLayer ) {
 
             tmx_object *head = pLayer ->  content.objgr -> head;
-            Color      color = IntToColor( pLayer ->  content.objgr -> color );
+            SunLight :: Base :: stColor  color = IntToColor( pLayer ->  content.objgr -> color );
 
             while( head ) {
                 if( head -> visible ) {
@@ -592,9 +571,12 @@ namespace SunLight {
          */
         void TileMapRenderer :: DrawImageLayer( tmx_layer *pLayer ) {
 
-            Texture2D *pTexture = ( Texture2D * ) pLayer -> content.image -> resource_image;
+            void *pImage = pLayer -> content.image -> resource_image;
 
-            DrawTexture( *pTexture, 0, 0, WHITE );
+            SunLight :: Engines :: EngineFactory :: GetEngine().DrawTexture( pImage,
+                                                                              0,
+                                                                              0,
+                                                                              SunLight :: Base :: stColor { 0xFF, 0xFF, 0xFF, 0xFF } );
         }
 
         /**
@@ -726,8 +708,11 @@ namespace SunLight {
          */
         void TileMapRenderer :: RenderMap( void ) {
 
-            if( m_bClearBackground )
-                ClearBackground( IntToColor( m_pTmxMap ? m_pTmxMap -> backgroundcolor : m_nWindowBackgroundColor ) );
+            if( m_bClearBackground )  {
+                SunLight :: Base :: stColor  bkColor = IntToColor( m_pTmxMap ? m_pTmxMap -> backgroundcolor : m_nWindowBackgroundColor );
+
+                ClearBackground( Color { bkColor.nRed, bkColor.nGreen, bkColor.nBlue, bkColor.nAlpha } );
+            }
 
             if( m_pTmxMap )
                 DrawAllLayers( m_pTmxMap -> ly_head );
@@ -1148,9 +1133,9 @@ namespace SunLight {
          * KeyboardKey enum);
          * The default exit is ESC Key;
          */
-        void TileMapRenderer :: SetExitKey( KeyboardKey key )  {
+        void TileMapRenderer :: SetExitKey( SunLight :: Input :: KeyboardKey key )  {
 
-            ::SetExitKey( key );
+            ::SetExitKey( ( KeyboardKey ) key );
         }
 
         /**

--- a/src/renderer/tilemaprenderer.h
+++ b/src/renderer/tilemaprenderer.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include <array>
 #include <map>
+#include <memory>
 #include "collision/collisionmanager.h"
 #include "tilemap/itilemaplistener.h"
 #include "input/iinputhandler.h"
@@ -73,14 +74,14 @@ namespace SunLight {
                 SunLight :: Input :: INPUT_EVENT_HANDLER  pHandler;
             };
 
-            typedef std :: deque<__stTileAnimInfo*> __AnimInfoList;
+            typedef std :: deque<std :: unique_ptr<__stTileAnimInfo>> __AnimInfoList;
             typedef std :: deque<SunLight :: TileMap :: ITileMapListener*> TileMapListenerList;
-            typedef std :: deque<__stInputEventData*> InputEventHandlerList;
+            typedef std :: deque<std :: unique_ptr<__stInputEventData>> InputEventHandlerList;
             typedef std :: deque<SunLight :: Sprite :: Sprite*> SpriteList;
             typedef std :: map<int, SpriteList*>                SpriteMap;
             typedef std :: deque<int> GamePadList;
 
-            SunLight :: Input :: IInputHandler         *m_pInputHandler;
+            std :: unique_ptr<SunLight :: Input :: IInputHandler>  m_pInputHandler;
             GamePadList                                m_GamePadList;
             SpriteMap                                  m_SpriteMap;
             TileMapListenerList                        m_TileMapListenerList;

--- a/src/renderer/tilemaprenderer.h
+++ b/src/renderer/tilemaprenderer.h
@@ -29,6 +29,8 @@
 #include "collision/collisionmanager.h"
 #include "tilemap/itilemaplistener.h"
 #include "input/iinputhandler.h"
+#include "base/color.h"
+#include "base/primitives.h"
 
 
 namespace SunLight {
@@ -37,7 +39,7 @@ namespace SunLight {
         /**
          * Primitive structures definition.
          */
-        typedef Vector2    stVector;
+        typedef SunLight :: Base :: stVector2D    stVector;
 
         /**
          * View port control mode (active and reactive)
@@ -118,43 +120,43 @@ namespace SunLight {
             void UnloadSprites( void );
 
             // Color control
-            Color IntToColor( uint32_t color );
+            SunLight :: Base :: stColor IntToColor( uint32_t color );
 
             // Graphics primitives miscellaneous
-            void SetPixel( int nCoordX, int nCoordY, Color color );
+            void SetPixel( int nCoordX, int nCoordY, SunLight :: Base :: stColor color );
             void MidPointEllipse( double fCoordX,
                                   double fCoordY,
                                   double fRadiusX,
                                   double fRadiusY,
-                                  Color color );
+                                  SunLight :: Base :: stColor color );
             void LineBresenham( int nX0,
                                 int nY0,
                                 int nX1,
                                 int nY1,
-                                Color color );
+                                SunLight :: Base :: stColor color );
 
             // Engine primitives
             void DrawPolyline( double fOffset_x,
                                double fOffset_y,
                                double **fPoints,
                                int nPointsCount,
-                               Color color );
+                               SunLight :: Base :: stColor color );
             void DrawPolygon( double fOffset_x,
                               double fOffset_y,
                               double **fPoints,
                               int nPointsCount,
-                              Color color );
+                              SunLight :: Base :: stColor color );
             void DrawRectangle( double offset_x,
                                 double offset_y,
                                 double width,
                                 double height,
-                                Color color );
+                                SunLight :: Base :: stColor color );
             void DrawEllipse( double offset_x,
                               double offset_y,
                               double width,
                               double height,
-                              Color color );
-            void DrawTile( void *pImage,
+                              SunLight :: Base :: stColor color );
+            void DrawTile( SunLight :: Base :: TextureHandle pImage,
                            int32_t nSourceX,
                            int32_t nSourceY,
                            int32_t nSourceW,
@@ -210,7 +212,7 @@ namespace SunLight {
             void RemoveTileMapListener( SunLight :: TileMap :: ITileMapListener *pListener );
 
             // Window behavior
-            void SetExitKey( KeyboardKey key );
+            void SetExitKey( SunLight :: Input :: KeyboardKey key );
             void SetWindowResizeable( bool bResizeable );
             void SetWindowBackgroundColor( uint32_t nWindowBkColor );
             void SetClearBackground( bool bStatus );

--- a/src/sound/soundmanager.cpp
+++ b/src/sound/soundmanager.cpp
@@ -51,10 +51,6 @@ namespace SunLight {
          */
         SoundManager :: ~SoundManager( void )  {
 
-            for( std :: pair<int, ISound*> item : m_SoundMap )  {
-                delete item.second;
-            }
-
             m_SoundMap.clear();
         }
 
@@ -68,15 +64,13 @@ namespace SunLight {
          */
         bool SoundManager :: Load( int nSoundId, std :: string strFileName )  {
 
-            __DEFAULT_ENGINE  *pSound = new __DEFAULT_ENGINE();
-            bool              bRet;
+            std :: unique_ptr<__DEFAULT_ENGINE>  pSound = std :: make_unique<__DEFAULT_ENGINE>();
+            bool                                 bRet;
 
             bRet = pSound -> Load( strFileName.c_str() );
 
-            if( !bRet )
-                delete pSound;
-            else
-                m_SoundMap.insert( std :: make_pair( nSoundId, pSound ) );
+            if( bRet )
+                m_SoundMap.insert( std :: make_pair( nSoundId, std :: move( pSound ) ) );
 
             return bRet;
         }
@@ -90,14 +84,13 @@ namespace SunLight {
          */
         bool SoundManager :: Unload( int nSoundId )  {
 
-            std :: map<int, ISound*> :: iterator itItem = m_SoundMap.find( nSoundId );
+            std :: map<int, std :: unique_ptr<ISound>> :: iterator itItem = m_SoundMap.find( nSoundId );
             bool   bRet = false;
 
             if( itItem != m_SoundMap.end() )  {
                 bRet = itItem -> second -> Unload();
 
                 if( bRet )  {
-                    delete itItem -> second;
                     m_SoundMap.erase( nSoundId );
                 }
             }
@@ -114,7 +107,7 @@ namespace SunLight {
          */
         bool SoundManager :: Play( int nSoundId )  {
 
-            std :: map<int, ISound*> :: iterator itItem = m_SoundMap.find( nSoundId );
+            std :: map<int, std :: unique_ptr<ISound>> :: iterator itItem = m_SoundMap.find( nSoundId );
             bool    bRet = false;
 
             if( itItem != m_SoundMap.end() )
@@ -132,7 +125,7 @@ namespace SunLight {
          */
         bool SoundManager :: Stop( int nSoundId )  {
 
-            std :: map<int, ISound*> :: iterator itItem = m_SoundMap.find( nSoundId );
+            std :: map<int, std :: unique_ptr<ISound>> :: iterator itItem = m_SoundMap.find( nSoundId );
             bool    bRet = false;
 
             if( itItem != m_SoundMap.end() )
@@ -150,7 +143,7 @@ namespace SunLight {
          */
         bool SoundManager :: Pause( int nSoundId )  {
 
-            std :: map<int, ISound*> :: iterator itItem = m_SoundMap.find( nSoundId );
+            std :: map<int, std :: unique_ptr<ISound>> :: iterator itItem = m_SoundMap.find( nSoundId );
             bool    bRet = false;
 
             if( itItem != m_SoundMap.end() )
@@ -167,7 +160,7 @@ namespace SunLight {
          */
         bool SoundManager :: Resume( int nSoundId )  {
 
-            std :: map<int, ISound*> :: iterator itItem = m_SoundMap.find( nSoundId );
+            std :: map<int, std :: unique_ptr<ISound>> :: iterator itItem = m_SoundMap.find( nSoundId );
             bool    bRet = false;
 
             if( itItem != m_SoundMap.end() )
@@ -185,7 +178,7 @@ namespace SunLight {
          */
         bool SoundManager :: IsPlaying( int nSoundId )  {
 
-            std :: map<int, ISound*> :: iterator itItem = m_SoundMap.find( nSoundId );
+            std :: map<int, std :: unique_ptr<ISound>> :: iterator itItem = m_SoundMap.find( nSoundId );
             bool    bRet = false;
 
             if( itItem != m_SoundMap.end() )

--- a/src/sound/soundmanager.h
+++ b/src/sound/soundmanager.h
@@ -23,6 +23,7 @@
 
 #include <string>
 #include <map>
+#include <memory>
 #include "isound.h"
 
 
@@ -31,11 +32,11 @@ namespace SunLight {
 
         /**
          * @brief Sound manager class implementation.
-         * 
+         *
          */
         class SoundManager  {
 
-            std :: map<int, ISound*>   m_SoundMap;
+            std :: map<int, std :: unique_ptr<ISound>>   m_SoundMap;
 
             public:
 

--- a/src/sprite/sprite.cpp
+++ b/src/sprite/sprite.cpp
@@ -74,10 +74,10 @@ namespace SunLight {
             pTexture -> SetDimension2DPtr( &spritePos );
 
             if( itItem == m_Sequences.end() )  {
-                TextureMap   *pTextureMap = new TextureMap();
+                std :: unique_ptr<TextureMap>   pTextureMap = std :: make_unique<TextureMap>();
 
                 pTextureMap -> AddTexture( pTexture, nDelayMilli );
-                m_Sequences.insert( std :: make_pair( nSequence, pTextureMap ) );
+                m_Sequences.insert( std :: make_pair( nSequence, std :: move( pTextureMap ) ) );
             }
             else  {
                 itItem -> second -> AddTexture( pTexture, nDelayMilli );
@@ -187,7 +187,7 @@ namespace SunLight {
         void Sprite :: Unload( void )  {
 
             if( m_Sequences.size() > 0 )  {
-                for( std :: pair<int, TextureMap*> pair : m_Sequences )  {
+                for( auto& pair : m_Sequences )  {
                     if( pair.second -> First() )  {
                         do  {
                             pair.second -> GetTextureData().pTexture -> Unload();

--- a/src/sprite/sprite.h
+++ b/src/sprite/sprite.h
@@ -22,6 +22,7 @@
 #define __SPRITE_H__
 
 #include <map>
+#include <memory>
 #include "collision/collider.h"
 #include "sprite/texturemap.h"
 
@@ -38,7 +39,7 @@ namespace SunLight {
              * @brief Texture sequence list definition.
              * 
              */
-            typedef std :: map<int, TextureMap*>  TextureSequenceList;
+            typedef std :: map<int, std :: unique_ptr<TextureMap>>  TextureSequenceList;
 
             TextureSequenceList             m_Sequences;
             TextureSequenceList :: iterator m_itActiveSequence;

--- a/src/sprite/texturemap.cpp
+++ b/src/sprite/texturemap.cpp
@@ -38,9 +38,6 @@ namespace SunLight {
          */
         TextureMap :: ~TextureMap( void )  {
 
-            for( stTextureData *pTexture : m_TextureList )  {
-                delete pTexture;
-            }
         }
 
         /**
@@ -52,15 +49,15 @@ namespace SunLight {
         void TextureMap :: AddTexture( SunLight :: Canvas :: TextureCanvas *pTexture,
                                        int64_t nDelayMilli )  {
 
-            stTextureData              *pData = new stTextureData;
-            steady_clock :: time_point now    = steady_clock :: now();
+            std :: unique_ptr<stTextureData>  pData = std :: make_unique<stTextureData>();
+            steady_clock :: time_point        now   = steady_clock :: now();
 
             pData -> pTexture    = pTexture;
             pData -> nDelayMilli = nDelayMilli;
             pData -> nNextTime   = duration_cast<milliseconds>( now.time_since_epoch() ).count();
             pData -> nNextTime+=nDelayMilli;
 
-            m_TextureList.push_back( pData );
+            m_TextureList.push_back( std :: move( pData ) );
 
             if( m_TextureList.size() == 1 )
                 First();

--- a/src/sprite/texturemap.h
+++ b/src/sprite/texturemap.h
@@ -21,6 +21,7 @@
 #ifndef __TEXTUREMAP_H__
 #define __TEXTUREMAP_H__
 
+#include <memory>
 #include <queue>
 #include <string>
 #include "canvas/texturecanvas.h"
@@ -57,7 +58,7 @@ namespace SunLight {
 
             private:
 
-            typedef std :: deque<stTextureData*> TextureList;
+            typedef std :: deque<std :: unique_ptr<stTextureData>> TextureList;
 
             TextureList               m_TextureList;
             TextureList :: iterator   m_itTexture;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,52 @@
+#  Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
+#
+#  This software is provided 'as-is', without any express or implied
+#  warranty. In no event will the authors be held liable for any damages
+#  arising from the use of this software.
+#
+#  Permission is granted to anyone to use this software for any purpose,
+#  including commercial applications, and to alter it and redistribute it
+#  freely, subject to the following restrictions:
+#
+#  1. The origin of this software must not be misrepresented; you must not
+#  claim that you wrote the original software. If you use this software
+#  in a product, an acknowledgment in the product documentation would be
+#  appreciated but is not required.
+#  2. Altered source versions must be plainly marked as such, and must not be
+#  misrepresented as being the original software.
+#  3. This notice may not be removed or altered from any source distribution.
+
+cmake_minimum_required (VERSION 3.24)
+
+project (sunlight_tests)
+
+include(FetchContent)
+
+if(APPLE)
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+
+####################################################################
+# doctest
+####################################################################
+FetchContent_Declare(doctest
+                     GIT_REPOSITORY https://github.com/doctest/doctest.git
+                     GIT_TAG v2.4.11)
+FetchContent_MakeAvailable(doctest)
+
+file(GLOB_RECURSE SUNLIGHT_TEST_SOURCES ./*.cpp)
+
+add_executable(sunlight_tests ${SUNLIGHT_TEST_SOURCES})
+add_dependencies(sunlight_tests sunlight)
+target_link_libraries(sunlight_tests PRIVATE sunlight doctest::doctest)
+
+add_custom_target(sunlight_tests_copy_binaries
+COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/
+COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:LibXml2> ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/
+COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:raylib> ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/
+COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:tmx> ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/
+COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:sunlight> ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/
+COMMENT "Copying sunlight_tests dependency binaries" VERBATIM)
+add_dependencies(sunlight_tests sunlight_tests_copy_binaries)
+
+add_test(NAME sunlight_tests COMMAND sunlight_tests)

--- a/tests/test_collider.cpp
+++ b/tests/test_collider.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include <doctest/doctest.h>
+#include "collision/collider.h"
+
+using namespace SunLight :: Collision;
+using namespace SunLight :: TileMap;
+
+TEST_SUITE( "collision/Collider" )  {
+
+    TEST_CASE( "Hit detects overlapping rectangles" )  {
+
+        Collider      collider;
+        stDimension2D self  { { 0, 0 }, { 50, 50 } };
+        stDimension2D other { { 25, 25 }, { 50, 50 } };
+
+        collider.SetDimension2D( self );
+
+        CHECK( collider.Hit( other ) == true );
+    }
+
+    TEST_CASE( "Hit rejects disjoint rectangles" )  {
+
+        Collider      collider;
+        stDimension2D self  { { 0, 0 }, { 50, 50 } };
+        stDimension2D other { { 100, 100 }, { 20, 20 } };
+
+        collider.SetDimension2D( self );
+
+        CHECK( collider.Hit( other ) == false );
+    }
+
+    TEST_CASE( "Hit treats exactly touching edges as a collision" )  {
+
+        Collider      collider;
+        stDimension2D self  { { 0, 0 }, { 50, 50 } };
+        stDimension2D other { { 50, 0 }, { 50, 50 } };
+
+        collider.SetDimension2D( self );
+
+        CHECK( collider.Hit( other ) == true );
+    }
+}

--- a/tests/test_helper.cpp
+++ b/tests/test_helper.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include <doctest/doctest.h>
+#include "general/helper.h"
+
+using namespace SunLight :: General;
+
+TEST_SUITE( "general/Helper" )  {
+
+    TEST_CASE( "Random stays within the requested inclusive range" )  {
+
+        for( int nCount = 0; nCount < 1000; nCount++ )  {
+            int nValue = Helper :: Random( 1, 10 );
+
+            CHECK( nValue >= 1 );
+            CHECK( nValue <= 10 );
+        }
+    }
+
+    TEST_CASE( "Random with equal bounds always returns that value" )  {
+
+        for( int nCount = 0; nCount < 20; nCount++ )  {
+            CHECK( Helper :: Random( 5, 5 ) == 5 );
+        }
+    }
+}

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>

--- a/tests/test_primitives.cpp
+++ b/tests/test_primitives.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include <doctest/doctest.h>
+#include "base/color.h"
+#include "base/primitives.h"
+
+using namespace SunLight :: Base;
+
+TEST_SUITE( "base/primitives" )  {
+
+    TEST_CASE( "stColor predefined constants hold expected channel values" )  {
+
+        stColor white = WHITE_COLOR;
+        stColor black = BLACK_COLOR;
+
+        CHECK( white.nRed   == 255 );
+        CHECK( white.nGreen == 255 );
+        CHECK( white.nBlue  == 255 );
+        CHECK( white.nAlpha == 255 );
+
+        CHECK( black.nRed   == 0 );
+        CHECK( black.nGreen == 0 );
+        CHECK( black.nBlue  == 0 );
+        CHECK( black.nAlpha == 255 );
+    }
+
+    TEST_CASE( "stRectangle stores its fields as given" )  {
+
+        stRectangle rect { 1.0f, 2.0f, 3.0f, 4.0f };
+
+        CHECK( rect.x      == doctest :: Approx( 1.0f ) );
+        CHECK( rect.y      == doctest :: Approx( 2.0f ) );
+        CHECK( rect.width  == doctest :: Approx( 3.0f ) );
+        CHECK( rect.height == doctest :: Approx( 4.0f ) );
+    }
+
+    TEST_CASE( "stVector2D stores its fields as given" )  {
+
+        stVector2D vec { 5.0f, 6.0f };
+
+        CHECK( vec.x == doctest :: Approx( 5.0f ) );
+        CHECK( vec.y == doctest :: Approx( 6.0f ) );
+    }
+
+    TEST_CASE( "TextureHandle defaults are comparable to nullptr" )  {
+
+        TextureHandle hTexture = nullptr;
+
+        CHECK( hTexture == nullptr );
+    }
+}

--- a/tests/test_viewport.cpp
+++ b/tests/test_viewport.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include <doctest/doctest.h>
+#include "base/viewport.h"
+
+using namespace SunLight :: Base;
+using namespace SunLight :: TileMap;
+
+TEST_SUITE( "base/Viewport" )  {
+
+    TEST_CASE( "default construction starts at 1.0 zoom factor with user zoom enabled" )  {
+
+        Viewport vp;
+
+        CHECK( vp.GetZoomProperties().fZoomFactor == doctest :: Approx( 1.0f ) );
+        CHECK( vp.GetZoomProperties().bEnabledUserZoom == true );
+    }
+
+    TEST_CASE( "ZoomIn/ZoomOut move the factor by one scale step and ResetZoom restores it" )  {
+
+        Viewport vp;
+        float    fBase = vp.GetZoomProperties().fZoomFactor;
+
+        vp.ZoomIn();
+        CHECK( vp.GetZoomProperties().fZoomFactor > fBase );
+
+        vp.ResetZoom();
+        CHECK( vp.GetZoomProperties().fZoomFactor == doctest :: Approx( fBase ) );
+
+        vp.ZoomOut();
+        CHECK( vp.GetZoomProperties().fZoomFactor < fBase );
+    }
+
+    TEST_CASE( "ZoomIn/ZoomOut are no-ops once user zoom is disabled" )  {
+
+        Viewport vp;
+        float    fBase = vp.GetZoomProperties().fZoomFactor;
+
+        vp.SetEnableUserZoom( false );
+        vp.ZoomIn();
+        vp.ZoomOut();
+
+        CHECK( vp.GetZoomProperties().fZoomFactor == doctest :: Approx( fBase ) );
+    }
+
+    TEST_CASE( "SetZoom is rejected once it falls outside the configured min/max border" )  {
+
+        Viewport vp;
+
+        vp.SetMinZoom( 10 );
+        vp.SetMaxZoom( 20 );
+
+        vp.SetZoom( 15 );
+        float fInRange = vp.GetZoomProperties().fZoomFactor;
+        CHECK( vp.GetZoomProperties().nCurrentZoomPos == 15 );
+
+        vp.SetZoom( 5 );
+        CHECK( vp.GetZoomProperties().fZoomFactor == doctest :: Approx( fInRange ) );
+
+        vp.SetZoom( 25 );
+        CHECK( vp.GetZoomProperties().fZoomFactor == doctest :: Approx( fInRange ) );
+    }
+
+    TEST_CASE( "GetClippedRect keeps a rectangle fully inside the viewport unchanged" )  {
+
+        Viewport      vp;
+        stDimension2D dst;
+        stDimension2D viewportDim { { 0, 0 }, { 800, 600 } };
+        stDimension2D src         { { 10, 10 }, { 100, 100 } };
+
+        vp.SetDimension2D( viewportDim );
+
+        CHECK( vp.GetClippedRect( src, dst ) == true );
+        CHECK( dst.pos.x == 10 );
+        CHECK( dst.pos.y == 10 );
+        CHECK( dst.size.nWidth  == 100 );
+        CHECK( dst.size.nHeight == 100 );
+    }
+
+    TEST_CASE( "GetClippedRect trims a rectangle crossing the right/bottom edge" )  {
+
+        Viewport      vp;
+        stDimension2D dst;
+        stDimension2D viewportDim { { 0, 0 }, { 800, 600 } };
+        stDimension2D src         { { 750, 10 }, { 100, 100 } };
+
+        vp.SetDimension2D( viewportDim );
+
+        CHECK( vp.GetClippedRect( src, dst ) == true );
+        CHECK( dst.size.nWidth == 50 );
+    }
+
+    TEST_CASE( "GetClippedRect rejects a rectangle fully outside the viewport" )  {
+
+        Viewport      vp;
+        stDimension2D dst;
+        stDimension2D viewportDim { { 0, 0 }, { 800, 600 } };
+        stDimension2D src         { { 900, 10 }, { 100, 100 } };
+
+        vp.SetDimension2D( viewportDim );
+
+        CHECK( vp.GetClippedRect( src, dst ) == false );
+    }
+
+    TEST_CASE( "GetClippedRect trims a rectangle starting before the viewport origin" )  {
+
+        Viewport      vp;
+        stDimension2D dst;
+        stDimension2D viewportDim { { 0, 0 }, { 800, 600 } };
+        stDimension2D src         { { -30, 10 }, { 100, 100 } };
+
+        vp.SetDimension2D( viewportDim );
+
+        CHECK( vp.GetClippedRect( src, dst ) == true );
+        CHECK( dst.pos.x == 0 );
+        CHECK( dst.size.nWidth == 70 );
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces the `__DEFAULT_ENGINE` macro duplicated across `tilemaprenderer.cpp`/`texturecanvas.cpp` with a single `IEngine` interface + `EngineFactory`, backed by `RaylibEngine`. `TextureCanvas`/`TileMapRenderer` no longer need `raylib.h` in their own headers and draw through native types (`stRectangle`, `stVector2D`, `stColor`, `TextureHandle` in new `base/primitives.h`).
- Adds a doctest-based unit test suite (`BUILD_LIBRARY_TESTS` option) covering `Viewport`, `Collider`, `Helper`, and the new primitives.
- Converts internally-owned raw pointers to `std::unique_ptr` across the sample `World` classes and the library (`Sprite`, `TextureMap`, `CollisionManager`, `SoundManager`, `InputHandlerFactory`, `TileMapRenderer`).
- Adds `CLAUDE.md` documenting the codebase for future sessions.

## Bugs found and fixed along the way
- `TileMapRenderer::SetExitKey` was silently binding to raylib's *global* `KeyboardKey` enum instead of `SunLight::Input::KeyboardKey`, only working because raylib.h happened to be transitively included first.
- `Viewport::InitializeZoomEngine` never initialized `nCurrentZoomPos`, so `ZoomIn`/`ZoomOut`/`GetZoomFactor` read uninitialized memory on a fresh `Viewport`.
- `Sprite::Unload()` leaked every `TextureMap*` it created (cleared the map without deleting the values) — fixed as a side effect of the `unique_ptr` conversion.
- `CollisionManager::Clear()` deleted elements without ever clearing the containers, leaving dangling pointers if called more than once — also fixed by the `unique_ptr` conversion.

## Test plan
- [x] `sunlight` library builds clean
- [x] Both samples (`sprite_test`, `tilemaprenderer_test`) build clean
- [x] `sunlight_tests`: 17 test cases / 2058 assertions, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)