### PR TITLE
Document IEngine interface methods

### DIFF
--- a/src/engines/iengine.h
+++ b/src/engines/iengine.h
@@ -40,18 +40,64 @@ namespace SunLight  {
 
             virtual ~IEngine( void )  {}
 
+            /**
+             * @brief Must be implemented to provide texture loading from disk based on
+             * chosen target engine;
+             *
+             * @param szFileName The texture file name to load;
+             * @param nWidth Output parameter receiving the loaded texture width;
+             * @param nHeight Output parameter receiving the loaded texture height;
+             * @return Opaque handle to the loaded texture, or nullptr if operation failed;
+             */
             virtual SunLight :: Base :: TextureHandle LoadTexture( const char *szFileName,
                                                                     int& nWidth,
                                                                     int& nHeight ) = 0;
+
+            /**
+             * @brief Must be implemented to unload previous texture data loaded by
+             * @see LoadTexture() method on chosen target engine;
+             *
+             * @param hTexture The texture handle to unload;
+             */
             virtual void UnloadTexture( SunLight :: Base :: TextureHandle hTexture ) = 0;
 
+            /**
+             * @brief Must be implemented to draw a pixel according the specified
+             * position on chosen target engine;
+             *
+             * @param nPosX The X coordinate to plot pixel;
+             * @param nPosY The Y coordinate to plot pixel;
+             * @param color Color of pixel;
+             */
             virtual void SetPixel( int nPosX, int nPosY, SunLight :: Base :: stColor color ) = 0;
 
+            /**
+             * @brief Must be implemented to draw a texture at the specified position
+             * on chosen target engine;
+             *
+             * @param hTexture The texture handle to draw;
+             * @param nPosX X coordinate to draw texture;
+             * @param nPosY Y coordinate to draw texture;
+             * @param tint Color tint applied to texture;
+             */
             virtual void DrawTexture( SunLight :: Base :: TextureHandle hTexture,
                                       int nPosX,
                                       int nPosY,
                                       SunLight :: Base :: stColor tint ) = 0;
 
+            /**
+             * @brief Must be implemented to draw part of a texture (defined by a
+             * rectangle) with rotation and scale tiled into dest on chosen target
+             * engine;
+             *
+             * @param hTexture The texture handle to draw;
+             * @param source Source rectangle defining the texture area to be drawn;
+             * @param dest Destination rectangle where texture will be tiled into;
+             * @param origin Origin point used as rotation/scale reference;
+             * @param rotation Rotation angle to be applied;
+             * @param scale Scale factor to be applied;
+             * @param tint Color tint applied to texture;
+             */
             virtual void DrawTextureTiled( SunLight :: Base :: TextureHandle hTexture,
                                            SunLight :: Base :: stRectangle source,
                                            SunLight :: Base :: stRectangle dest,


### PR DESCRIPTION
## Summary
- Adds doxygen-style comments to `IEngine`'s pure virtual methods, matching the existing convention used by `ISound`/`ICollisionManager` (`@brief`, `@param`, `@return`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)