### PR TITLE
Remove dead HandleGamePadEvent declaration

### DIFF
--- a/src/renderer/tilemaprenderer.h
+++ b/src/renderer/tilemaprenderer.h
@@ -188,7 +188,6 @@ namespace SunLight {
 
             // User interaction handlers
             inline void HandleKeyEvent( SunLight :: Input :: KeyboardKey key );
-            inline void HandleGamePadEvent( SunLight :: Input :: GamepadButton key );
             inline void HandleUserInput( void );
             inline void HandleUserUpdate( void );
             inline void HandleUserCollisions( void );


### PR DESCRIPTION
## Summary
- \`HandleGamePadEvent( SunLight::Input::GamepadButton key )\` was declared in \`tilemaprenderer.h\` but never defined or called anywhere in the codebase — unlike every other \`Handle*\` private method, which has a matching implementation in \`tilemaprenderer.cpp\`. Removing the dead declaration.

## Test plan
- [x] Library rebuilds clean after removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)