### PR TITLE
Add GitHub Actions CI (Linux/macOS/Windows)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,19 +35,19 @@ jobs:
             libwayland-dev \
             libxkbcommon-dev
 
-      - name: Install Windows dependencies (zlib via vcpkg)
+      - name: Install Windows dependencies (zlib, iconv via vcpkg)
         if: runner.os == 'Windows'
         shell: pwsh
-        run: vcpkg install zlib:x64-windows
+        run: vcpkg install zlib:x64-windows libiconv:x64-windows
 
       - name: Configure (Linux/macOS)
         if: runner.os != 'Windows'
-        run: cmake -B build -S . -DBUILD_LIBRARY_SAMPLES=ON -DBUILD_LIBRARY_TESTS=ON
+        run: cmake -B build -S . -DBUILD_LIBRARY_SAMPLES=ON -DBUILD_LIBRARY_TESTS=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
       - name: Configure (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
-        run: cmake -B build -S . -DBUILD_LIBRARY_SAMPLES=ON -DBUILD_LIBRARY_TESTS=ON -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+        run: cmake -B build -S . -DBUILD_LIBRARY_SAMPLES=ON -DBUILD_LIBRARY_TESTS=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 
       - name: Build
         run: cmake --build build --config Release -j 4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Configure (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
-        run: cmake -B build -S . -DBUILD_LIBRARY_SAMPLES=ON -DBUILD_LIBRARY_TESTS=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+        run: cmake -B build -S . -DBUILD_LIBRARY_SAMPLES=ON -DBUILD_LIBRARY_TESTS=ON "-DCMAKE_POLICY_VERSION_MINIMUM=3.5" "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 
       - name: Build
         run: cmake --build build --config Release -j 4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            zlib1g-dev \
+            libasound2-dev \
+            libx11-dev \
+            libxrandr-dev \
+            libxi-dev \
+            libgl1-mesa-dev \
+            libglu1-mesa-dev \
+            libxcursor-dev \
+            libxinerama-dev \
+            libwayland-dev \
+            libxkbcommon-dev
+
+      - name: Install Windows dependencies (zlib via vcpkg)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: vcpkg install zlib:x64-windows
+
+      - name: Configure (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: cmake -B build -S . -DBUILD_LIBRARY_SAMPLES=ON -DBUILD_LIBRARY_TESTS=ON
+
+      - name: Configure (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: cmake -B build -S . -DBUILD_LIBRARY_SAMPLES=ON -DBUILD_LIBRARY_TESTS=ON -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+
+      - name: Build
+        run: cmake --build build --config Release -j 4
+
+      - name: Run unit tests
+        run: ctest --test-dir build --output-on-failure -C Release


### PR DESCRIPTION
## Summary
- Adds \`.github/workflows/ci.yml\`: builds the library, both samples, and the test suite, then runs \`sunlight_tests\` via \`ctest\`, on Linux/macOS/Windows.
- Triggers on every push to \`main\` and every PR targeting \`main\`.
- Linux installs zlib + raylib's documented apt dependencies; Windows uses the vcpkg install already present on GitHub-hosted \`windows-latest\` runners for zlib (libxml2/tmx are fetched from source on all platforms per the existing CMakeLists, so no vcpkg needed for those); macOS needs nothing extra.

## Test plan
- [ ] Watching the Actions run on this PR itself to verify all three platforms pass — will iterate here if any fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)