### PR TITLE
Pin libxml2 and tmx dependencies to stable release tags

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,16 +45,16 @@ if(NOT USE_LOCAL_LIBXML2)
 
     FetchContent_Declare(libxml2 OVERRIDE_FIND_PACKAGE
                          GIT_REPOSITORY https://github.com/GNOME/libxml2.git
-                         GIT_TAG master)
+                         GIT_TAG v2.15.3)
     FetchContent_MakeAvailable(libxml2)
 endif()
 
 ####################################################################
 # TMX
 ####################################################################
-FetchContent_Declare(tmx 
+FetchContent_Declare(tmx
                      GIT_REPOSITORY https://github.com/baylej/tmx.git
-                     GIT_TAG master)
+                     GIT_TAG tmx_1.10.1)
 FetchContent_MakeAvailable(tmx)
 
 ####################################################################


### PR DESCRIPTION
## Summary
- \`libxml2\` and \`tmx\` were both fetched with \`GIT_TAG master\` (unpinned, unlike \`raylib\` which is already pinned to \`5.5\`) — a fresh configure on different days could silently pull different upstream commits, breaking build reproducibility.
- Pins \`libxml2\` to \`v2.15.3\` (this is what \`master\` already resolved to during this session's builds, so no behavior change — just makes it explicit) and \`tmx\` to \`tmx_1.10.1\` (latest tagged release).

## Test plan
- [x] Full clean rebuild locally (fresh \`build/\` dir, forcing a re-fetch of both pinned tags): library, both samples, and the test suite all build clean
- [x] \`sunlight_tests\`: 17 test cases / 2058 assertions, all passing
- [ ] Also watching this PR's CI run across Linux/macOS/Windows for confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)