### PR TITLE
Fix broken install() rule: actually generate and install a usable CMake package

### DIFF
--- a/cmake/sunlightConfig.cmake.in
+++ b/cmake/sunlightConfig.cmake.in
@@ -1,0 +1,37 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(ZLIB)
+find_dependency(LibXml2)
+if(UNIX)
+    find_dependency(Threads)
+endif()
+
+# raylib and tmx are vendored (fetched from source as part of building
+# sunlight, see src/CMakeLists.txt) rather than exported as find_package-able
+# dependencies. Their compiled shared libraries are installed alongside
+# sunlight's own (see the install(TARGETS sunlight raylib tmx ...) call), the
+# same way samples/*/CMakeLists.txt copies them next to each sample
+# executable, so they're available at runtime without a consumer needing to
+# find_package() them separately.
+
+set_and_check(SUNLIGHT_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+
+if(NOT TARGET sunlight::sunlight)
+    add_library(sunlight::sunlight SHARED IMPORTED)
+
+    set_target_properties(sunlight::sunlight PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${SUNLIGHT_INCLUDE_DIR}")
+
+    if(WIN32)
+        set_target_properties(sunlight::sunlight PROPERTIES
+            IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/sunlight.lib"
+            IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_BINDIR@/sunlight.dll")
+    else()
+        set_target_properties(sunlight::sunlight PROPERTIES
+            IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_LIBDIR@/${CMAKE_SHARED_LIBRARY_PREFIX}sunlight${CMAKE_SHARED_LIBRARY_SUFFIX}")
+    endif()
+endif()
+
+check_required_components(sunlight)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
-project (sunlight)
+project (sunlight VERSION 0.1.0)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
@@ -40,8 +40,9 @@ if(NOT USE_LOCAL_LIBXML2)
         add_definitions(-DHAVE_SYS_RANDOM_H=1)
     endif()
 
-    set(LIBXML2_WITH_PYTHON OFF) # Turn off Python bind build dependency
-    set(LIBXML2_WITH_TESTS OFF)  # Turn off tests build dependency
+    set(LIBXML2_WITH_PYTHON OFF)   # Turn off Python bind build dependency
+    set(LIBXML2_WITH_TESTS OFF)    # Turn off tests build dependency
+    set(LIBXML2_WITH_PROGRAMS OFF) # Turn off xmllint/xmlcatalog CLI tools - sunlight only needs the library
 
     FetchContent_Declare(libxml2 OVERRIDE_FIND_PACKAGE
                          GIT_REPOSITORY https://github.com/GNOME/libxml2.git
@@ -159,5 +160,30 @@ target_link_libraries(sunlight ${CMAKE_THREAD_LIBS_INIT} raylib tmx LibXml2::Lib
 
 target_include_directories(sunlight INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}> $<INSTALL_INTERFACE:include>)
 
+# raylib/tmx are fetched from source, not find_package-imported. install(EXPORT)
+# would require the whole transitive dependency graph (raylib -> glfw -> ...)
+# to also be export-set-clean, which vendored FetchContent targets aren't
+# designed for. Instead: install the binaries directly (no EXPORT, so no graph
+# validation - this mirrors how samples/ already vendors these runtime deps
+# next to each sample executable) and hand-write the imported target in
+# sunlightConfig.cmake.in rather than generating one via install(EXPORT).
+install(TARGETS sunlight raylib tmx
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        FILES_MATCHING PATTERN "*.h")
+
+configure_package_config_file(${CMAKE_SOURCE_DIR}/cmake/sunlightConfig.cmake.in
+                               ${CMAKE_BINARY_DIR}/sunlightConfig.cmake
+                               INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sunlight
+                               PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_BINDIR)
+
+write_basic_package_version_file(${CMAKE_BINARY_DIR}/sunlightConfigVersion.cmake
+                                  VERSION ${PROJECT_VERSION}
+                                  COMPATIBILITY SameMajorVersion)
+
 install(FILES "${CMAKE_BINARY_DIR}/sunlightConfig.cmake" "${CMAKE_BINARY_DIR}/sunlightConfigVersion.cmake"
-        DESTINATION "lib/cmake/sunlight")
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sunlight)


### PR DESCRIPTION
## Summary
\`install()\` previously only referenced \`sunlightConfig.cmake\`/\`sunlightConfigVersion.cmake\`, but neither file was ever generated anywhere in the build — \`cmake --install\` failed outright. Nothing installed the \`sunlight\` target or its headers either.

- Adds \`project(sunlight VERSION 0.1.0)\` — \`write_basic_package_version_file()\` needs a real version to generate a meaningful ConfigVersion file.
- \`install(TARGETS sunlight raylib tmx ...)\` installs the compiled libraries. \`raylib\`/\`tmx\` are vendored via FetchContent (not \`find_package\`-imported), so they're installed alongside \`sunlight\` the same way \`samples/*/CMakeLists.txt\` already copies them next to each sample executable — this makes them available to a consumer at runtime.
- \`install(DIRECTORY ... FILES_MATCHING PATTERN "*.h")\` installs all headers, preserving the \`base/canvas/collision/...\` subdirectory structure the existing \`#include\` style depends on.
- \`cmake/sunlightConfig.cmake.in\` hand-declares the \`sunlight::sunlight\` IMPORTED target and \`find_dependency()\`s ZLIB/LibXml2/Threads, rather than using \`install(EXPORT)\`. \`install(EXPORT)\` was tried first, but it requires the full transitive link graph to be export-set-clean (\`sunlight -> raylib -> glfw -> ...\`), which vendored FetchContent targets aren't designed for — CMake errors on the first un-exported transitive dependency it finds. The plain \`install(TARGETS)\` (no \`EXPORT\` keyword) avoids that graph validation entirely.
- Also disables \`LIBXML2_WITH_PROGRAMS\` (xmllint/xmlcatalog CLI tools) since \`sunlight\` only needs the library, and building just the \`sunlight\` target left those tools' own \`install()\` rules pointing at binaries that were never built.

## Test plan
- [x] Full clean rebuild (library, both samples, test suite)
- [x] \`sunlight_tests\`: 17 test cases / 2058 assertions, all passing
- [x] \`cmake --install\` succeeds end-to-end into a scratch prefix
- [x] A separate throwaway consumer CMake project ran \`find_package(sunlight REQUIRED)\`, linked \`sunlight::sunlight\`, and built+ran successfully against the installed headers/libs
- [ ] Watching this PR's normal CI (build + sunlight_tests, not the install step) across Linux/macOS/Windows for regressions from the CMakeLists.txt changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)