### PR TITLE
Update MISSING_FEATURES.md: CI, dependency pinning, and install() fix are done

### DIFF
--- a/doc/MISSING_FEATURES.md
+++ b/doc/MISSING_FEATURES.md
@@ -4,26 +4,29 @@ This tracks project-level gaps found during a review of the build system, releas
 scaffolding, CI, and test/sample coverage — as opposed to `TODO.txt`/`FIXME.txt`,
 which track in-engine feature/bug work.
 
-## Real risks
+## Resolved
 
-- **Broken `install()` rule.** `src/CMakeLists.txt` installs `sunlightConfig.cmake`
-  and `sunlightConfigVersion.cmake`, but neither file is ever generated — there is
-  no `configure_package_config_file()`/`write_basic_package_version_file()` call
-  and no `.cmake.in` template anywhere in the repo. `cmake --install` fails today.
-- **Unpinned dependencies.** `libxml2` and `tmx` are both fetched with
-  `GIT_TAG master` (unlike `raylib`, which is pinned to `5.5`). Two builds done on
-  different days can silently pull different upstream commits, so builds aren't
-  reproducible, and an upstream breaking change on either library can break
-  `sunlight` with no warning.
-- **No CI.** There is no `.github/workflows` (or any other CI) at all. A real test
-  suite exists (`tests/`, 17 cases / 2058 assertions) but nothing runs it
-  automatically on push or PR — regressions are only caught if someone remembers
-  to build and test locally before merging.
+- ~~No CI~~ — `.github/workflows/ci.yml` builds the library, both samples, and
+  the test suite, then runs `sunlight_tests` via `ctest`, on Linux/macOS/Windows,
+  on every push to `main` and every PR. The three `build (<os>)` jobs are also
+  required status checks on `main`'s branch protection. (#40)
+- ~~Unpinned dependencies~~ — `libxml2` (`v2.15.3`) and `tmx` (`tmx_1.10.1`) are
+  now pinned to stable release tags, matching `raylib` (`5.5`). (#41)
+- ~~Broken `install()` rule~~ — `cmake --install` now actually generates
+  `sunlightConfig.cmake`/`sunlightConfigVersion.cmake`, installs the `sunlight`
+  target, its headers, and the vendored `raylib`/`tmx` runtime libs, and a
+  `sunlight::sunlight` imported target is hand-declared in
+  `cmake/sunlightConfig.cmake.in` (avoiding `install(EXPORT)`'s transitive
+  export-set requirement, which vendored FetchContent targets aren't built for).
+  `project(sunlight)` also gained a `VERSION 0.1.0`, needed for the generated
+  ConfigVersion file. Verified end-to-end against a standalone external consumer
+  project. (#42)
 
 ## Missing scaffolding
 
-- No version anywhere: `project(sunlight)` has no `VERSION`, and there are no git
-  tags/releases. There's no way to tell a consumer "you're on v0.x".
+- No git tags/releases yet — `project(sunlight VERSION 0.1.0)` exists now (added
+  while fixing the `install()` rule), but there's still no tagged release, so
+  there's no way to tell a consumer "you're on v0.x" from git history alone.
 - No `CONTRIBUTING.md`, `SECURITY.md`, or `CHANGELOG.md`.
 - No Doxygen config. Every header already uses consistent `@brief`/`@param`
   doxygen-style comments, but none of it is ever rendered into browsable docs.


### PR DESCRIPTION
## Summary
All three "real risks" items from \`doc/MISSING_FEATURES.md\` are resolved: CI (#40), dependency pinning (#41), and the broken \`install()\` rule (#42). Moves them to a Resolved section and updates the versioning note now that \`project(sunlight)\` has a \`VERSION\`.

Doc-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)