### PR TITLE
Fix sunlightConfig.cmake.in path resolution when consumed via FetchContent

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,7 +176,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         FILES_MATCHING PATTERN "*.h")
 
-configure_package_config_file(${CMAKE_SOURCE_DIR}/cmake/sunlightConfig.cmake.in
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/sunlightConfig.cmake.in
                                ${CMAKE_BINARY_DIR}/sunlightConfig.cmake
                                INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sunlight
                                PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_BINDIR)


### PR DESCRIPTION
## Summary
A user integrating \`sunlight\` into their own project via \`FetchContent\` hit:
\`\`\`
CMake Error: File /Volumes/Data/Projects/Source/C_CPP/game-engine/cmake/sunlightConfig.cmake.in does not exist.
\`\`\`

\`configure_package_config_file()\` (added in #42) used \`CMAKE_SOURCE_DIR\` to locate \`cmake/sunlightConfig.cmake.in\`. That variable always points at the **outermost** project's source dir for the whole CMake invocation — correct when \`sunlight\` is built standalone, but wrong when an external project \`FetchContent\`s it, since then \`CMAKE_SOURCE_DIR\` resolves to the *external* project's root, not \`sunlight\`'s own.

Fixed by using \`CMAKE_CURRENT_SOURCE_DIR\` instead, which always tracks \`src/\`'s own directory regardless of how deeply nested/fetched it is.

## Test plan
- [x] Reproduced the exact failure with a throwaway external project \`FetchContent\`-ing this local checkout
- [x] Confirmed the fix resolves it — the throwaway consumer now configures and builds \`sunlight\` cleanly
- [x] Re-verified the standalone path still works: fresh configure, full build, \`sunlight_tests\` (17/17 passing), and \`cmake --install\` into a scratch prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)