### PR TITLE
Add IEngine::GetApplicationDirectory() for resource path resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ The core library lives in `src/`, one namespace per module under `SunLight::<Mod
 - `canvas` / `sprite` — `Canvas`/`TextureCanvas` (single animated texture with tiling/zoom-aware blit) and `Sprite` (named sequences of `TextureCanvas`s, e.g. walk-cycle frames).
 - `input` — `IInputHandler` + `InputHandlerFactory`, backed by `input/raylib/RaylibInputHandler`.
 - `sound` — `SoundManager` behind `ISound`, backed by `sound/raylib/RayLibSound`.
-- `engines` — `IEngine` (`SetPixel`, `DrawTexture`, `DrawTextureTiled`, `LoadTexture`/`UnloadTexture`) + `EngineFactory::GetEngine()`, backed by `engines/raylib/RaylibEngine`. The seam through which the actual raylib draw calls happen.
+- `engines` — `IEngine` (`SetPixel`, `DrawTexture`, `DrawTextureTiled`, `LoadTexture`/`UnloadTexture`, `GetApplicationDirectory`) + `EngineFactory::GetEngine()`, backed by `engines/raylib/RaylibEngine`. The seam through which the actual raylib draw calls happen.
 - `scripting`, `concurrent`, `general` — script listener hooks, a `Timer` utility, `Helper::Random()`.
 
 ### Backend abstraction pattern

--- a/src/engines/iengine.h
+++ b/src/engines/iengine.h
@@ -21,6 +21,7 @@
 #ifndef __IENGINE_H__
 #define __IENGINE_H__
 
+#include <string>
 #include "base/color.h"
 #include "base/primitives.h"
 
@@ -105,6 +106,19 @@ namespace SunLight  {
                                            float rotation,
                                            float scale,
                                            SunLight :: Base :: stColor tint ) = 0;
+
+            /**
+             * @brief Must be implemented to return the directory the running
+             * executable lives in (trailing separator included), so callers
+             * can resolve resource paths relative to the binary instead of
+             * hardcoding an absolute, machine-specific path. Does not depend
+             * on the backend's window/render context having been
+             * initialized yet.
+             *
+             * @return The application's own directory, or an empty string
+             * if it could not be determined;
+             */
+            virtual std :: string GetApplicationDirectory( void ) = 0;
         };
     }
 }

--- a/src/engines/raylib/raylibengine.cpp
+++ b/src/engines/raylib/raylibengine.cpp
@@ -288,6 +288,21 @@ namespace SunLight  {
 
                 ::DrawTexture( *pTexture, nPosX, nPosY, Color{ tint.nRed, tint.nGreen, tint.nBlue, tint.nAlpha } );
             }
+
+            /**
+             * @brief Return the directory the running executable lives in.
+             * Copies raylib's own internal static buffer into an owned
+             * std::string immediately, so the result stays valid regardless
+             * of subsequent raylib calls.
+             * @return The application's own directory, or an empty string
+             * if it could not be determined;
+             */
+            std :: string RaylibEngine :: GetApplicationDirectory( void )  {
+
+                const char *szDirectory = ::GetApplicationDirectory();
+
+                return ( szDirectory ? std :: string( szDirectory ) : std :: string() );
+            }
         }
     }
 }

--- a/src/engines/raylib/raylibengine.h
+++ b/src/engines/raylib/raylibengine.h
@@ -55,6 +55,8 @@ namespace SunLight  {
                                        float rotation,
                                        float scale,
                                        SunLight :: Base :: stColor tint ) override;
+
+                std :: string GetApplicationDirectory( void ) override;
             };
         }
     }


### PR DESCRIPTION
## Summary
- Adds \`GetApplicationDirectory()\` to \`IEngine\`/\`RaylibEngine\`, letting callers resolve resource paths relative to the running executable instead of hardcoding an absolute, machine-specific path. Needed by an external project consuming \`sunlight\` via \`FetchContent\`.
- Returns \`std::string\` rather than raylib's native \`const char*\` — raylib's \`::GetApplicationDirectory()\` reuses an internal static buffer across calls, so \`RaylibEngine\`'s implementation copies it into an owned string immediately to avoid a dangling-pointer footgun for callers.
- Updates \`CLAUDE.md\`'s module map to list the new method.

## Test plan
- [x] Full clean rebuild (library + test suite)
- [x] \`sunlight_tests\`: 17 test cases / 2058 assertions, all passing
- [ ] Watching this PR's CI across Linux/macOS/Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)