### PR TITLE
Use VCPKG_ROOT env var instead of a hardcoded vcpkg path in VSCode sample settings

### DIFF
--- a/doc/vscode/.vscode_sample/settings.windows.json
+++ b/doc/vscode/.vscode_sample/settings.windows.json
@@ -2,8 +2,8 @@
     "cmake.configureOnOpen": true,
     "cmake.configureSettings": {
             "BUILD_LIBRARY_SAMPLES": true,
-            "CMAKE_PREFIX_PATH": "C:/dev/vcpkg/installed/x64-windows",
+            "CMAKE_PREFIX_PATH": "${env:VCPKG_ROOT}/installed/x64-windows",
             "CMAKE_TOOLCHAIN_FILE":
-                "C:/dev/vcpkg/scripts/buildsystems/vcpkg.cmake"
+                "${env:VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
         }
 }

--- a/doc/vscode/README.md
+++ b/doc/vscode/README.md
@@ -34,7 +34,7 @@ There's 3 settings ready for using on your preferred system.
 
 * settings.linux.json Specific settings for Linux;
 * settings.macos.json Specific settings for MacOs;
-* settings.windows.json Specific settings for Windows (with vckpg configuration)
+* settings.windows.json Specific settings for Windows (with vcpkg configuration; assumes the `VCPKG_ROOT` environment variable is set to your vcpkg installation, as set up by `vcpkg integrate install`)
 
 For example, consider you're developing on Linux platform, so you could use this ready made **settings.linux.json** by copying it to the **settings.json** file of your **.vscode** folder present on root path of your `sunlight` project copy.
 


### PR DESCRIPTION
## Summary
- \`settings.windows.json\` hardcoded \`CMAKE_PREFIX_PATH\`/\`CMAKE_TOOLCHAIN_FILE\` to \`C:/dev/vcpkg\`, assuming every Windows developer cloned vcpkg to that exact path.
- Uses \`\${env:VCPKG_ROOT}\` instead, matching vcpkg's own standard environment variable (set by \`vcpkg integrate install\`), so the sample works regardless of where vcpkg is actually installed.
- Notes the \`VCPKG_ROOT\` prerequisite in \`doc/vscode/README.md\`.

Doc-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)