### PR TITLE
Add TileMapRenderer::SetWindowTitle() for changing the window title post-creation

### DIFF
--- a/src/renderer/tilemaprenderer.cpp
+++ b/src/renderer/tilemaprenderer.cpp
@@ -1339,6 +1339,20 @@ namespace SunLight {
         }
 
         /**
+         * @brief Set the application window's title, replacing whatever
+         * title it was created with.
+         *
+         * @param strTitle The new window title;
+         */
+        void TileMapRenderer :: SetWindowTitle( const std :: string &strTitle )  {
+
+            m_strTitle = strTitle;
+
+            if( m_bIsStarted )
+                :: SetWindowTitle( m_strTitle.c_str() );
+        }
+
+        /**
          * Set layer parameters.
          * @param nLayerId The layer id to set layer parameters;
          * @param layer reference to layer parameters structure to set;

--- a/src/renderer/tilemaprenderer.h
+++ b/src/renderer/tilemaprenderer.h
@@ -243,6 +243,9 @@ namespace SunLight {
             void MoveCameraLeft( void );
             void MoveCameraRight( void );
 
+            // Window management
+            void SetWindowTitle( const std :: string &strTitle );
+
             // Layer management
             bool SetLayer( int nLayerId, SunLight :: TileMap :: stLayer& layer );
             bool SetLayer( const char *szLayerName, SunLight :: TileMap :: stLayer &layer );

--- a/src/tilemap/itilemap.h
+++ b/src/tilemap/itilemap.h
@@ -24,6 +24,7 @@
 #include "sprite/sprite.h"
 #include "input/iinputhandler.h"
 #include "collision/icollisionmanager.h"
+#include <string>
 
 
 namespace SunLight {
@@ -126,6 +127,14 @@ namespace SunLight {
              * Move view camera right.
              */
             virtual void MoveCameraRight( void ) = 0;
+
+            /**
+             * @brief Set the application window's title, replacing whatever
+             * title it was created with.
+             *
+             * @param strTitle The new window title;
+             */
+            virtual void SetWindowTitle( const std :: string &strTitle ) = 0;
 
             /**
              * Set layer parameters.


### PR DESCRIPTION
## Summary
- Adds \`SetWindowTitle\` to \`ITileMap\`/\`TileMapRenderer\`, letting callers update the window title after the window is already created (e.g. to show FPS, score, or status in the title bar) instead of only being able to set it once via the constructor.
- Guards the raylib \`::SetWindowTitle()\` call with \`m_bIsStarted\`, matching the established pattern other window-touching methods in this class already use (\`UnloadMap\`, \`Stop\`, the layer setters) — so calling this before \`Start()\` just updates the stored \`m_strTitle\` (which \`Start()\` already reads when it calls \`InitWindow\`) without touching a not-yet-created raylib window, the same idea \`SetWindowBackgroundColor\` already uses.

## Test plan
- [x] Full clean rebuild (library + test suite)
- [x] \`sunlight_tests\`: 17 test cases / 2058 assertions, all passing
- [ ] Watching this PR's CI across Linux/macOS/Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)