### PR TITLE
Write real usage docs for the sprite and tilemaprenderer samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,4 +114,5 @@ If you intend to use VsCode as your IDE, follow the instructions shown [here](/d
 
 ## Samples :sunny:
 
-In order to get proper info on the samples usage, you may find more on [here](/samples/tilemaprenderer/docs/README.md).
+* [tilemaprenderer](/samples/tilemaprenderer/docs/README.md) — the minimal setup: loads a Tiled map and drives the renderer's camera/zoom, no sprites.
+* [sprite](/samples/sprite/docs/README.md) — builds on `tilemaprenderer` by adding an animated `Sprite` on top of the map.

--- a/samples/sprite/docs/README.md
+++ b/samples/sprite/docs/README.md
@@ -1,3 +1,47 @@
-# using samples
+# sprite sample
 
-All files need to compile the samples are found on the `samples` folder. 
+This sample builds on [tilemaprenderer](/samples/tilemaprenderer/docs/README.md) by adding an animated `Sprite` ("Sunny") on top of the loaded map — it's the smallest example of `sunlight`'s sprite/animation API: loading a texture into a `TextureCanvas`, wrapping it in a `Sprite` texture sequence, and registering it with the renderer on a specific map layer.
+
+## Building
+
+From the project root, enable samples and build:
+
+```shell
+cmake -B build -S . -DBUILD_LIBRARY_SAMPLES=ON
+cmake --build build -j 4
+```
+
+This produces the `sprite_test` executable under `build/samples/sprite/`, along with the raylib/tmx/LibXml2/sunlight shared libraries copied next to it (required at runtime).
+
+## Running
+
+`sprite_test` resolves its map/sprite resources relative to a base path passed as `argv[1]` — point it at this sample's own directory:
+
+```shell
+./build/samples/sprite/sprite_test samples/sprite/
+```
+
+## Controls
+
+| Keys | Action |
+| --- | --- |
+| `W` / `Up Arrow` | Scroll the view up |
+| `S` / `Down Arrow` | Scroll the view down |
+| `A` / `Left Arrow` | Scroll the view left |
+| `D` / `Right Arrow` | Scroll the view right |
+| `Page Up` | Zoom out |
+| `Page Down` | Zoom in |
+| `Home` | Reset zoom to the default level |
+
+The current FPS is drawn in the corner of the window.
+
+## What it shows
+
+- `World::LoadSprites()` ([world.cpp](/samples/sprite/world.cpp)) loads `resources/sprites/sunny_idle_down.png` into a `TextureCanvas`, splits it into 32×32 tiles, and sets `TEXTURE_ANIMATION_MODE_AUTOMATIC_CIRCULAR` so it cycles through the frames on its own.
+- The canvas is added as sequence `0` of a `Sprite`, which is then registered on the renderer's layer `4` via `TileMapRenderer::AddSprite()` — sprites are drawn per-layer, interleaved with the tilemap's own layers.
+- The rest of `World` mirrors the [tilemaprenderer sample](/samples/tilemaprenderer/docs/README.md): same camera/zoom controls, same `resources/map/test.tmx` map, same viewport setup.
+
+## Resources
+
+- `resources/map/` — the Tiled `.tmx` map and its tilesets (shared layout with the `tilemaprenderer` sample).
+- `resources/sprites/sunny_idle_down.png` — the sprite sheet used for the animated character.

--- a/samples/tilemaprenderer/docs/README.md
+++ b/samples/tilemaprenderer/docs/README.md
@@ -1,3 +1,45 @@
-# using samples
+# tilemaprenderer sample
 
-All files need to compile the samples are found on the `samples` folder. 
+The simplest `sunlight` sample: loads a Tiled `.tmx` map and drives `TileMapRenderer`'s game loop, camera scrolling, and zoom — no sprites, no collisions, just the map renderer on its own. See the [sprite sample](/samples/sprite/docs/README.md) for the same setup with an animated character added on top.
+
+## Building
+
+From the project root, enable samples and build:
+
+```shell
+cmake -B build -S . -DBUILD_LIBRARY_SAMPLES=ON
+cmake --build build -j 4
+```
+
+This produces the `tilemaprenderer_test` executable under `build/samples/tilemaprenderer/`, along with the raylib/tmx/LibXml2/sunlight shared libraries copied next to it (required at runtime).
+
+## Running
+
+`tilemaprenderer_test` resolves its map resources relative to a base path passed as `argv[1]` — point it at this sample's own directory:
+
+```shell
+./build/samples/tilemaprenderer/tilemaprenderer_test samples/tilemaprenderer/
+```
+
+## Controls
+
+| Keys | Action |
+| --- | --- |
+| `W` / `Up Arrow` | Scroll the view up |
+| `S` / `Down Arrow` | Scroll the view down |
+| `A` / `Left Arrow` | Scroll the view left |
+| `D` / `Right Arrow` | Scroll the view right |
+| `Page Up` | Zoom out |
+| `Page Down` | Zoom in |
+| `Home` | Reset zoom to the default level |
+
+The current FPS is drawn in the corner of the window.
+
+## What it shows
+
+- `World::Run()` ([world.cpp](/samples/tilemaprenderer/world.cpp)) constructs a `TileMapRenderer`, sets up a 900×800 viewport with a default zoom level, wires the controls above via `SetUserKeyEventHandler`, then loads `resources/map/test.tmx` centered in the window (`MAP_ALIGNMENT_CENTER`) before entering the render loop with `Run()`.
+- This is the minimal setup needed to get a Tiled map on screen — everything else in the library (sprites, collisions, sound, scripting) builds on top of this same `TileMapRenderer` instance.
+
+## Resources
+
+- `resources/map/` — the Tiled `.tmx` map and its tilesets, shared with the `sprite` sample.


### PR DESCRIPTION
## Summary
Both \`samples/*/docs/README.md\` files were placeholder stubs ("using samples... All files need to compile the samples are found on the samples folder"), despite the root README linking to them as the source of "proper info on the samples usage".

Documents building, running (the \`argv[1]\` base-path convention), the actual key bindings from each sample's \`world.cpp\`, and what each sample demonstrates:
- \`tilemaprenderer\` — the minimal map-rendering setup
- \`sprite\` — builds on it by adding an animated character via \`TextureCanvas\`/\`Sprite\`

Doc-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)