### PR TITLE
Add right-stick handling for GAMEPAD_BUTTON_RIGHT_FACE_* events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Internal containers/members that exclusively own heap-allocated data (e.g. `Spri
 
 ## Known issues (tracked in `doc/`)
 - `doc/FIXME.txt`: access violation when map scroll goes past viewport boundaries.
-- `doc/TODO.txt`: no isometric/hexagonal map support; missing some gamepad face-button bindings; per-layer parallax scrolling and per-object property management (opacity/visible/position) not implemented; sprite/layer draw-order still being finished.
+- `doc/TODO.txt`: no isometric/hexagonal map support; per-layer parallax scrolling and per-object property management (opacity/visible/position) not implemented; sprite/layer draw-order still being finished.
 
 ## Git workflow
 

--- a/doc/TODO.txt
+++ b/doc/TODO.txt
@@ -4,6 +4,4 @@ This is a TODO list with improvements and new features;
 * Add sprite order drawing on layer, respecting it's layer order; 
 * Add support to individual layer camera moving to enable effects like scroll parallax;
 * Isometric support to renderer;
-* Hexagonal support to renderer;
-* Add support to GAMEPAD_BUTTON_RIGHT_FACE_UP, GAMEPAD_BUTTON_RIGHT_FACE_DOWN, GAMEPAD_BUTTON_RIGHT_FACE_LEFT, GAMEPAD_BUTTON_RIGHT_FACE_RIGHT missing 
-*  event handling on TileMapRenderer (Check TileMapRenderer :: HandleUserInput method); 
+* Hexagonal support to renderer; 

--- a/src/renderer/tilemaprenderer.cpp
+++ b/src/renderer/tilemaprenderer.cpp
@@ -867,26 +867,34 @@ namespace SunLight {
             bool    bEventHandled = false;
 
             for( int nGamePadId : m_GamePadList )  {
-                SunLight :: Input :: GamepadButton button[]    = { SunLight :: Input :: GamepadButton :: GAMEPAD_BUTTON_UNKNOWN, 
+                SunLight :: Input :: GamepadButton button[]    = { SunLight :: Input :: GamepadButton :: GAMEPAD_BUTTON_UNKNOWN,
+                                                                   SunLight :: Input :: GamepadButton :: GAMEPAD_BUTTON_UNKNOWN,
+                                                                   SunLight :: Input :: GamepadButton :: GAMEPAD_BUTTON_UNKNOWN,
                                                                    SunLight :: Input :: GamepadButton :: GAMEPAD_BUTTON_UNKNOWN };
-                float    fPosX = m_pInputHandler -> GetGamepadAxisMovement( nGamePadId, 
+                float    fPosX = m_pInputHandler -> GetGamepadAxisMovement( nGamePadId,
                                                                             SunLight :: Input :: GamepadAxis :: GAMEPAD_AXIS_LEFT_X );
-                float    fPosY = m_pInputHandler -> GetGamepadAxisMovement( nGamePadId, 
+                float    fPosY = m_pInputHandler -> GetGamepadAxisMovement( nGamePadId,
                                                                             SunLight :: Input :: GamepadAxis :: GAMEPAD_AXIS_LEFT_Y );
+                float    fRightPosX = m_pInputHandler -> GetGamepadAxisMovement( nGamePadId,
+                                                                                 SunLight :: Input :: GamepadAxis :: GAMEPAD_AXIS_RIGHT_X );
+                float    fRightPosY = m_pInputHandler -> GetGamepadAxisMovement( nGamePadId,
+                                                                                 SunLight :: Input :: GamepadAxis :: GAMEPAD_AXIS_RIGHT_Y );
 
                 // Calculate deadzones
-                if( ( fPosX > -ctfLeftStickDeadzoneX ) && ( fPosX < ctfLeftStickDeadzoneX ) ) 
+                if( ( fPosX > -ctfLeftStickDeadzoneX ) && ( fPosX < ctfLeftStickDeadzoneX ) )
                     fPosX = 0.0f;
-                if( ( fPosY > -ctfRightStickDeadzoneY ) && ( fPosY < ctfRightStickDeadzoneY ) ) 
+                if( ( fPosY > -ctfRightStickDeadzoneY ) && ( fPosY < ctfRightStickDeadzoneY ) )
                     fPosY = 0.0f;
+                if( ( fRightPosX > -ctfRightStickDeadzoneX ) && ( fRightPosX < ctfRightStickDeadzoneX ) )
+                    fRightPosX = 0.0f;
+                if( ( fRightPosY > -ctfRightStickDeadzoneY ) && ( fRightPosY < ctfRightStickDeadzoneY ) )
+                    fRightPosY = 0.0f;
 
-                // TODO: Code sample for future use when add support to Right stick and trigger handling  
-                // if (rightStickX > -ctfRightStickDeadzoneX && rightStickX < ctfRightStickDeadzoneX) rightStickX = 0.0f;
-                // if (rightStickY > -rightStickDeadzoneY && rightStickY < rightStickDeadzoneY) rightStickY = 0.0f;
+                // TODO: Code sample for future use when add support to trigger handling
                 // if (leftTrigger < leftTriggerDeadzone) leftTrigger = -1.0f;
                 // if (rightTrigger < rightTriggerDeadzone) rightTrigger = -1.0f;
 
-                // Handle Analog GamePad control stick
+                // Handle Analog GamePad control stick (left)
                 if( fPosX > 0.0 )  {
                     button[0] = SunLight :: Input :: GamepadButton :: GAMEPAD_BUTTON_LEFT_FACE_RIGHT;
                     bEventHandled = true;
@@ -909,13 +917,36 @@ namespace SunLight {
                     }
                 }
 
-                // Handle DPad control stick
+                // Handle Analog GamePad control stick (right)
+                if( fRightPosX > 0.0 )  {
+                    button[2] = SunLight :: Input :: GamepadButton :: GAMEPAD_BUTTON_RIGHT_FACE_RIGHT;
+                    bEventHandled = true;
+                }
+                else  {
+                    if( fRightPosX < 0.0 )  {
+                        button[2] = SunLight :: Input :: GamepadButton :: GAMEPAD_BUTTON_RIGHT_FACE_LEFT;
+                        bEventHandled = true;
+                    }
+                }
+
+                if( fRightPosY > 0.0 )  {
+                    button[3] = SunLight :: Input :: GamepadButton :: GAMEPAD_BUTTON_RIGHT_FACE_DOWN;
+                    bEventHandled = true;
+                }
+                else  {
+                    if( fRightPosY < 0.0 )  {
+                        button[3] = SunLight :: Input :: GamepadButton :: GAMEPAD_BUTTON_RIGHT_FACE_UP;
+                        bEventHandled = true;
+                    }
+                }
+
+                // Handle DPad and analog stick controls (left + right)
                 for( InputEventHandlerList :: iterator itItem = m_GPadInputEventHandlerList.begin(); itItem != m_GPadInputEventHandlerList.end(); itItem++ )  {
                     SunLight :: Input :: GamepadButton   evt = ( SunLight :: Input :: GamepadButton ) ( * itItem ) -> nEvent;
-                    
+
                     /*
                      * DPad and Analog MUST be processed in the same handler list iteration.
-                     * The order of events can affect main renderer processing behavior 
+                     * The order of events can affect main renderer processing behavior
                      * (depending on final developer game logic);
                      */
                     if( m_pInputHandler -> IsGamepadButtonDown( nGamePadId, evt ) )  {
@@ -923,7 +954,7 @@ namespace SunLight {
                         bEventHandled = true;
                     }
                     else  {
-                        if( ( evt == button[0] ) || ( evt == button[1] ) )  {
+                        if( ( evt == button[0] ) || ( evt == button[1] ) || ( evt == button[2] ) || ( evt == button[3] ) )  {
                             ( * itItem ) -> pHandler( SunLight :: Input :: ControllerType :: CONTROLLER_GAMEPAD, nGamePadId );
                             bEventHandled = true;
                         }


### PR DESCRIPTION
## Summary
- `TileMapRenderer::HandleUserInput()` mapped left-stick tilt to virtual `GAMEPAD_BUTTON_LEFT_FACE_*` presses so a handler registered via `SetUserGamePadEventHandler` fires from either the DPad or the left stick. The right stick had no equivalent, so `GAMEPAD_BUTTON_RIGHT_FACE_UP/DOWN/LEFT/RIGHT` handlers only fired from the physical face buttons (Y/A/X/B), never the right stick — tracked as a TODO in both `doc/TODO.txt` and an in-code comment.
- Added the same deadzone + virtual-button mapping for the right stick (`GAMEPAD_AXIS_RIGHT_X/Y`), extending the existing dispatch loop to check it alongside the left-stick and real-button cases.
- Removed the now-resolved TODO bullet from `doc/TODO.txt` and `CLAUDE.md`'s Known issues summary.

## Test plan
- [x] `cmake --build build --target sunlight` — clean build
- [x] `sunlight_tests`: 17/17 cases, 2058/2058 assertions passing
- [ ] No gamepad hardware available to manually verify the right stick dispatch in this environment — logic mirrors the already-shipped, working left-stick path exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)