### PR TITLE
Add SoundManager test coverage via a mock ISound

### DIFF
--- a/doc/MISSING_FEATURES.md
+++ b/doc/MISSING_FEATURES.md
@@ -21,6 +21,11 @@ which track in-engine feature/bug work.
   `project(sunlight)` also gained a `VERSION 0.1.0`, needed for the generated
   ConfigVersion file. Verified end-to-end against a standalone external consumer
   project. (#42)
+- ~~No `SoundManager` test coverage~~ — `SoundFactory::CreateSound()` now isolates
+  `SoundManager` from the concrete `RayLibSound` backend (#52), and `SoundFactory::SetCreator()`
+  gives tests a seam to substitute a mock `ISound`. `tests/test_soundmanager.cpp` covers
+  `Load`/`Unload`/`Play`/`Stop`/`Pause`/`Resume`/`IsPlaying`'s id-keyed dispatch and
+  bookkeeping against a `MockSound` test double, with no real audio device involved.
 
 ## Missing scaffolding
 
@@ -35,9 +40,9 @@ which track in-engine feature/bug work.
 
 ## Test / sample coverage gaps
 
-- Tests only cover pure-logic code (`Viewport`, `Collider`, `Helper`,
-  `base/primitives.h`). `TileMapRenderer`, `Sprite`, `CollisionManager`,
-  `SoundManager`, and `ScriptProcessor` have zero test coverage.
+- Tests cover pure-logic code (`Viewport`, `Collider`, `Helper`, `base/primitives.h`)
+  plus `SoundManager` (via a mock `ISound`, see above). `TileMapRenderer`, `Sprite`,
+  `CollisionManager`, and `ScriptProcessor` still have zero test coverage.
   Now that `IEngine` is a real interface, a mock `IEngine` implementation could
   unlock testing `TileMapRenderer`'s input/collision/sprite-dispatch logic
   without a real window — that wasn't possible before the engine abstraction.

--- a/src/sound/soundfactory.cpp
+++ b/src/sound/soundfactory.cpp
@@ -36,13 +36,26 @@
 namespace SunLight {
     namespace Sound  {
 
+        static SoundFactory :: CreatorFunction   s_pCreator = nullptr;
+
         /**
-         * @brief Create a new @see ISound instance of the backend selected
-         * at build time.
+         * @brief Create a new @see ISound instance - the backend selected
+         * at build time, unless overridden by @see SetCreator() (tests only).
          */
         std :: unique_ptr<ISound> SoundFactory :: CreateSound( void )  {
 
+            if( s_pCreator )
+                return s_pCreator();
+
             return std :: make_unique<__DEFAULT_ENGINE>();
+        }
+
+        /**
+         * @brief Override the backend used by @see CreateSound().
+         */
+        void SoundFactory :: SetCreator( CreatorFunction creator )  {
+
+            s_pCreator = creator;
         }
     }
 }

--- a/src/sound/soundfactory.h
+++ b/src/sound/soundfactory.h
@@ -23,6 +23,7 @@
 
 #include "isound.h"
 #include <memory>
+#include <functional>
 
 
 namespace SunLight {
@@ -43,7 +44,20 @@ namespace SunLight {
 
             public:
 
+            typedef std :: function<std :: unique_ptr<ISound>( void )>  CreatorFunction;
+
             static std :: unique_ptr<ISound> CreateSound( void );
+
+            /**
+             * @brief Override the backend used by @see CreateSound() - for
+             * tests only, to substitute a mock @see ISound without a real
+             * audio device. Pass an empty @see CreatorFunction to restore
+             * the default, build-time backend.
+             *
+             * @param creator The replacement creator function, or an empty
+             * std::function to reset back to the default backend;
+             */
+            static void SetCreator( CreatorFunction creator );
         };
     }
 }

--- a/tests/mock_sound.h
+++ b/tests/mock_sound.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef __MOCK_SOUND_H__
+#define __MOCK_SOUND_H__
+
+#include "sound/isound.h"
+#include "sound/soundfactory.h"
+#include <string>
+
+/**
+ * @brief Test double for SunLight::Sound::ISound - records call counts and
+ * the last file name passed to Load(), and returns a per-instance result
+ * for each method so tests can force success/failure paths.
+ */
+class MockSound : public SunLight :: Sound :: ISound  {
+
+    public:
+
+    bool          bLoadResult      = true;
+    bool          bUnloadResult    = true;
+    bool          bPlayResult      = true;
+    bool          bStopResult      = true;
+    bool          bPauseResult     = true;
+    bool          bResumeResult    = true;
+    bool          bIsPlayingResult = false;
+
+    int           nLoadCalls      = 0;
+    int           nUnloadCalls    = 0;
+    int           nPlayCalls      = 0;
+    int           nStopCalls      = 0;
+    int           nPauseCalls     = 0;
+    int           nResumeCalls    = 0;
+    int           nIsPlayingCalls = 0;
+
+    std :: string strLastFileName;
+
+    bool Load( std :: string strFileName )  {
+        nLoadCalls++;
+        strLastFileName = strFileName;
+        return bLoadResult;
+    }
+
+    bool Unload( void )  {
+        nUnloadCalls++;
+        return bUnloadResult;
+    }
+
+    bool Play( void )  {
+        nPlayCalls++;
+        return bPlayResult;
+    }
+
+    bool Stop( void )  {
+        nStopCalls++;
+        return bStopResult;
+    }
+
+    bool Pause( void )  {
+        nPauseCalls++;
+        return bPauseResult;
+    }
+
+    bool Resume( void )  {
+        nResumeCalls++;
+        return bResumeResult;
+    }
+
+    bool IsPlaying( void )  {
+        nIsPlayingCalls++;
+        return bIsPlayingResult;
+    }
+};
+
+/**
+ * @brief RAII fixture that points SoundFactory :: CreateSound() at freshly
+ * created MockSound instances for the fixture's lifetime, restoring the
+ * default (real) backend on destruction. pLastCreated tracks the most
+ * recently created mock so tests can inspect/configure it.
+ *
+ * Gotcha: SoundManager owns the ISound it creates and destroys it the
+ * moment it's no longer kept (Load() returning false never stores it;
+ * a successful Unload() erases it from the map) - so pLastCreated dangles
+ * right after either of those. Only dereference it before the call that
+ * discards the sound, or to configure it before that call happens.
+ */
+class MockSoundFixture  {
+
+    public:
+
+    MockSound   *pLastCreated  = nullptr;
+    bool         bNextLoadResult = true;
+
+    MockSoundFixture( void )  {
+        SunLight :: Sound :: SoundFactory :: SetCreator( [this]( void ) -> std :: unique_ptr<SunLight :: Sound :: ISound>  {
+            std :: unique_ptr<MockSound>  pMock = std :: make_unique<MockSound>();
+
+            pMock -> bLoadResult = bNextLoadResult;
+            pLastCreated = pMock.get();
+
+            return pMock;
+        } );
+    }
+
+    ~MockSoundFixture( void )  {
+        SunLight :: Sound :: SoundFactory :: SetCreator( nullptr );
+    }
+};
+
+#endif /* __MOCK_SOUND_H__ */

--- a/tests/test_soundmanager.cpp
+++ b/tests/test_soundmanager.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include <doctest/doctest.h>
+#include "sound/soundmanager.h"
+#include "mock_sound.h"
+
+using namespace SunLight :: Sound;
+
+TEST_SUITE( "sound/SoundManager" )  {
+
+    TEST_CASE( "Load creates a sound via SoundFactory and stores it under the given id" )  {
+
+        MockSoundFixture  fixture;
+        SoundManager      manager;
+
+        CHECK( manager.Load( 1, "test.wav" ) == true );
+        REQUIRE( fixture.pLastCreated != nullptr );
+        CHECK( fixture.pLastCreated -> nLoadCalls == 1 );
+        CHECK( fixture.pLastCreated -> strLastFileName == "test.wav" );
+    }
+
+    TEST_CASE( "Load returns false and does not store the sound when the backend fails" )  {
+
+        MockSoundFixture  fixture;
+        SoundManager      manager;
+
+        fixture.bNextLoadResult = false;
+
+        // A failed Load() is never stored in m_SoundMap, so the mock created
+        // for it is destroyed before this call returns - pLastCreated would
+        // dangle if dereferenced here (see MockSoundFixture's doc comment).
+        // Id 1 was never inserted, so every later operation on it must
+        // report failure.
+        CHECK( manager.Load( 1, "bad.wav" ) == false );
+        CHECK( manager.Play( 1 ) == false );
+    }
+
+    TEST_CASE( "Play/Stop/Pause/Resume/IsPlaying forward to the loaded sound" )  {
+
+        MockSoundFixture  fixture;
+        SoundManager      manager;
+
+        manager.Load( 5, "a.wav" );
+        REQUIRE( fixture.pLastCreated != nullptr );
+
+        fixture.pLastCreated -> bIsPlayingResult = true;
+
+        CHECK( manager.Play( 5 ) == true );
+        CHECK( fixture.pLastCreated -> nPlayCalls == 1 );
+
+        CHECK( manager.Stop( 5 ) == true );
+        CHECK( fixture.pLastCreated -> nStopCalls == 1 );
+
+        CHECK( manager.Pause( 5 ) == true );
+        CHECK( fixture.pLastCreated -> nPauseCalls == 1 );
+
+        CHECK( manager.Resume( 5 ) == true );
+        CHECK( fixture.pLastCreated -> nResumeCalls == 1 );
+
+        CHECK( manager.IsPlaying( 5 ) == true );
+        CHECK( fixture.pLastCreated -> nIsPlayingCalls == 1 );
+    }
+
+    TEST_CASE( "Operations on an unknown sound id return false without creating any sound" )  {
+
+        MockSoundFixture  fixture;
+        SoundManager      manager;
+
+        CHECK( manager.Play( 999 ) == false );
+        CHECK( manager.Stop( 999 ) == false );
+        CHECK( manager.Pause( 999 ) == false );
+        CHECK( manager.Resume( 999 ) == false );
+        CHECK( manager.IsPlaying( 999 ) == false );
+        CHECK( manager.Unload( 999 ) == false );
+
+        CHECK( fixture.pLastCreated == nullptr );
+    }
+
+    TEST_CASE( "Unload only erases the sound once the backend unload succeeds" )  {
+
+        MockSoundFixture  fixture;
+        SoundManager      manager;
+
+        manager.Load( 3, "a.wav" );
+        REQUIRE( fixture.pLastCreated != nullptr );
+
+        fixture.pLastCreated -> bUnloadResult = false;
+
+        CHECK( manager.Unload( 3 ) == false );
+        CHECK( fixture.pLastCreated -> nUnloadCalls == 1 );
+
+        // Still present in the map - operations must still reach the mock.
+        CHECK( manager.Play( 3 ) == true );
+
+        fixture.pLastCreated -> bUnloadResult = true;
+
+        // A successful Unload() erases the entry from m_SoundMap, which
+        // destroys the mock - pLastCreated would dangle if dereferenced
+        // after this call (see MockSoundFixture's doc comment).
+        CHECK( manager.Unload( 3 ) == true );
+
+        // Erased now - further operations report failure.
+        CHECK( manager.Play( 3 ) == false );
+    }
+}


### PR DESCRIPTION
## Summary
- `SoundFactory` gains `SetCreator()` ([soundfactory.h](src/sound/soundfactory.h)) - a test-only seam that overrides what `CreateSound()` returns, restoring the real backend when passed an empty `std::function`.
- `tests/mock_sound.h` adds `MockSound` (a call-counting, result-configurable `ISound` test double) and `MockSoundFixture` (RAII glue that points `SoundFactory` at fresh mocks for a test's lifetime, resetting on destruction).
- `tests/test_soundmanager.cpp` covers `SoundManager`'s id-keyed bookkeeping: `Load()` stores under the right id and forwards the file name; a failed `Load()` isn't stored; `Play`/`Stop`/`Pause`/`Resume`/`IsPlaying` forward to the loaded sound and return `false` on an unknown id; `Unload()` only erases once the backend unload succeeds. No real audio device touched.
- Closes the `SoundManager` test-coverage gap tracked in `doc/MISSING_FEATURES.md` (updated here).

## A bug I hit and fixed along the way
First pass at the tests read mock call counts *after* the call that discards the mock - `SoundManager` destroys its `ISound` the moment it's no longer kept (a failed `Load()` is never stored; a successful `Unload()` erases the map entry). That's a dangling-pointer read, not a library bug - confirmed by instrumenting both sides with temporary debug prints before removing them. Fixed by only inspecting the mock before the discarding call, documented on `MockSoundFixture`.

## Test plan
- [x] `cmake --build build --target sunlight_tests` - clean build
- [x] `sunlight_tests`: 22/22 cases, 2088/2088 assertions passing (5 new `SoundManager` cases, 30 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)