### PR TITLE
Add CollisionManager test coverage via a mock ITileMap

### DIFF
--- a/doc/MISSING_FEATURES.md
+++ b/doc/MISSING_FEATURES.md
@@ -32,6 +32,14 @@ which track in-engine feature/bug work.
   it covers `TextureCanvas::Load`/`Unload`/`Update` against a `MockEngine` test
   double (texture handle plumbing, size adoption on load, and draw dispatch gated
   on visibility/viewport clipping).
+- ~~No `CollisionManager` test coverage~~ — `tests/mock_tilemap.h` adds `MockTileMap`,
+  a stub `ITileMap` implementing only what `CollisionManager` actually calls on its
+  parent (`GetLayer`, `TileMapToTileMatrix`, `GetTile`). `tests/test_collisionmanager.cpp`
+  covers layer-id validation on `AddCollider`/`AddColliderToColliderRule`/
+  `AddColliderToTileRule`, `Update()`'s collider-to-collider dispatch (fires only for
+  overlapping colliders on a paired layer, respects `RemoveCollider`), and the
+  collider-to-tile path's failure/no-op branches, including a real (but
+  collision-shape-less) `tmx_tile` to exercise `Collider::Hit(stTile&)` safely.
 
 ## Missing scaffolding
 
@@ -47,10 +55,11 @@ which track in-engine feature/bug work.
 ## Test / sample coverage gaps
 
 - Tests cover pure-logic code (`Viewport`, `Collider`, `Helper`, `base/primitives.h`),
-  `SoundManager` (via a mock `ISound`), and `TextureCanvas` (via a mock `IEngine`,
-  see above). `TileMapRenderer`, `Sprite`, `CollisionManager`, and `ScriptProcessor`
-  still have zero test coverage - the `MockEngine`/`EngineFactory::SetEngine()` seam
-  now exists for them too, but `TileMapRenderer` also owns its window lifecycle
+  `SoundManager` (via a mock `ISound`), `TextureCanvas` (via a mock `IEngine`), and
+  `CollisionManager` (via a mock `ITileMap`, see above). `TileMapRenderer`, `Sprite`,
+  and `ScriptProcessor` still have zero test coverage - the `MockEngine`/
+  `EngineFactory::SetEngine()` seam exists for `Sprite` too (it just forwards to its
+  active `TextureCanvas`), but `TileMapRenderer` also owns its window lifecycle
   (`InitWindow`, `BeginDrawing`/`EndDrawing`, ...) directly via raylib, so only the
   parts of it that route through `IEngine` are unlockable this way, not the whole class.
 - No sample demonstrates `SoundManager` or `ScriptProcessor` (`samples/tilemaprenderer`,

--- a/tests/mock_tilemap.h
+++ b/tests/mock_tilemap.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef __MOCK_TILEMAP_H__
+#define __MOCK_TILEMAP_H__
+
+#include "tilemap/itilemap.h"
+#include <map>
+#include <stdexcept>
+
+/**
+ * @brief Test double for SunLight::TileMap::ITileMap - only implements the
+ * subset CollisionManager actually calls (GetLayer, TileMapToTileMatrix,
+ * GetTile) with configurable results; everything else is a trivial stub
+ * since CollisionManager never reaches it. GetInputHandler()/
+ * GetCollisionManager() throw if called - there's no sane mock value for
+ * either and CollisionManager doesn't call them on its parent.
+ */
+class MockTileMap : public SunLight :: TileMap :: ITileMap  {
+
+    public:
+
+    std :: map<int, SunLight :: TileMap :: stLayer>  layersById;
+
+    bool bTileMapToTileMatrixResult = true;
+    SunLight :: TileMap :: stMatrixPosition  tileMapToTileMatrixResult { 0, 0 };
+
+    bool bGetTileResult = false;
+    SunLight :: TileMap :: stTile  getTileResult {};
+
+    int  nGetTileCalls              = 0;
+    int  nTileMapToTileMatrixCalls  = 0;
+
+    void AddGamePad( int )  {}
+    void SetUserKeyEventHandler( SunLight :: Input :: KeyboardKey, SunLight :: Input :: INPUT_EVENT_HANDLER )  {}
+    void SetUserGamePadEventHandler( SunLight :: Input :: GamepadButton, SunLight :: Input :: INPUT_EVENT_HANDLER )  {}
+
+    SunLight :: Input :: IInputHandler& GetInputHandler( void )  {
+        throw std :: logic_error( "MockTileMap::GetInputHandler not mocked" );
+    }
+
+    void ResetZoom( void )  {}
+    void ZoomIn( void )  {}
+    void ZoomOut( void )  {}
+    void ResetCamera( void )  {}
+    void MoveCameraUp( void )  {}
+    void MoveCameraDown( void )  {}
+    void MoveCameraLeft( void )  {}
+    void MoveCameraRight( void )  {}
+    void SetWindowTitle( const std :: string& )  {}
+
+    bool SetLayer( int, SunLight :: TileMap :: stLayer& )  {
+        return false;
+    }
+
+    bool SetLayer( const char*, SunLight :: TileMap :: stLayer& )  {
+        return false;
+    }
+
+    bool GetLayer( int nLayerId, SunLight :: TileMap :: stLayer& layer )  {
+        std :: map<int, SunLight :: TileMap :: stLayer> :: iterator itItem = layersById.find( nLayerId );
+
+        if( itItem == layersById.end() )
+            return false;
+
+        layer = itItem -> second;
+        return true;
+    }
+
+    bool GetLayer( const char*, SunLight :: TileMap :: stLayer& )  {
+        return false;
+    }
+
+    bool GetTile( const SunLight :: TileMap :: stMatrixPosition& pos,
+                  const SunLight :: TileMap :: stLayer& layer,
+                  SunLight :: TileMap :: stTile& tile )  {
+        nGetTileCalls++;
+        tile = getTileResult;
+        return bGetTileResult;
+    }
+
+    bool TileMapToTileMatrix( const SunLight :: TileMap :: stCoordinate2D&,
+                              SunLight :: TileMap :: stMatrixPosition& pos )  {
+        nTileMapToTileMatrixCalls++;
+        pos = tileMapToTileMatrixResult;
+        return bTileMapToTileMatrixResult;
+    }
+
+    bool GetMapInfo( SunLight :: TileMap :: stMapInfo& )  {
+        return false;
+    }
+
+    SunLight :: Collision :: ICollisionManager& GetCollisionManager( void )  {
+        throw std :: logic_error( "MockTileMap::GetCollisionManager not mocked" );
+    }
+
+    bool AddSprite( int, SunLight :: Sprite :: Sprite& )  {
+        return false;
+    }
+
+    bool RemoveSprite( int, SunLight :: Sprite :: Sprite& )  {
+        return false;
+    }
+
+    bool LoadMap( const char*, SunLight :: TileMap :: ITileMap :: MapAlignment )  {
+        return false;
+    }
+
+    bool UnloadMap( void )  {
+        return false;
+    }
+};
+
+#endif /* __MOCK_TILEMAP_H__ */

--- a/tests/test_collisionmanager.cpp
+++ b/tests/test_collisionmanager.cpp
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include <doctest/doctest.h>
+#include "collision/collisionmanager.h"
+#include "mock_tilemap.h"
+#include <vector>
+#include <utility>
+
+using namespace SunLight :: Collision;
+using namespace SunLight :: TileMap;
+
+namespace  {
+
+    /**
+     * @brief Records every OnCollision() call it receives, so tests can
+     * assert on what CollisionManager :: Update() actually fired.
+     */
+    class TestCollisionListener : public ICollisionListener  {
+
+        public:
+
+        std :: vector<std :: pair<Collider*, Collider*>>  colliderHits;
+        std :: vector<Collider*>                          tileHits;
+
+        void OnCollision( Collider *pFirst, Collider *pSecond )  {
+            colliderHits.push_back( { pFirst, pSecond } );
+        }
+
+        void OnCollision( Collider *pFirst, stTile *pSecond )  {
+            tileHits.push_back( pFirst );
+        }
+    };
+}
+
+TEST_SUITE( "collision/CollisionManager" )  {
+
+    TEST_CASE( "AddCollider accepts a valid layer id and rejects an out-of-range one" )  {
+
+        MockTileMap        tileMap;
+        CollisionManager   manager( &tileMap );
+        Collider           collider;
+
+        CHECK( manager.AddCollider( 0, &collider ) == true );
+        CHECK( manager.AddCollider( MAX_COLLIDER_LAYERS, &collider ) == false );
+    }
+
+    TEST_CASE( "AddColliderToColliderRule pairs two layers exactly once" )  {
+
+        MockTileMap        tileMap;
+        CollisionManager   manager( &tileMap );
+
+        CHECK( manager.AddColliderToColliderRule( 0, 1 ) == true );
+        CHECK( manager.AddColliderToColliderRule( 0, 1 ) == false );
+    }
+
+    TEST_CASE( "Update fires OnCollision only for overlapping colliders on a paired layer" )  {
+
+        MockTileMap             tileMap;
+        CollisionManager        manager( &tileMap );
+        TestCollisionListener   listener;
+        Collider                colliderA, colliderB, colliderC;
+        stDimension2D           dimA { { 0, 0 },     { 50, 50 } };
+        stDimension2D           dimB { { 25, 25 },   { 50, 50 } };  // overlaps A
+        stDimension2D           dimC { { 500, 500 }, { 10, 10 } };  // does not overlap A
+
+        colliderA.SetDimension2D( dimA );
+        colliderB.SetDimension2D( dimB );
+        colliderC.SetDimension2D( dimC );
+
+        manager.AddCollider( 0, &colliderA );
+        manager.AddCollider( 1, &colliderB );
+        manager.AddCollider( 1, &colliderC );
+        manager.AddColliderToColliderRule( 0, 1 );
+        manager.AddCollisionListener( &listener );
+
+        manager.Update();
+
+        REQUIRE( listener.colliderHits.size() == 1 );
+        CHECK( listener.colliderHits[0].first  == &colliderA );
+        CHECK( listener.colliderHits[0].second == &colliderB );
+    }
+
+    TEST_CASE( "Update ignores colliders on layers with no rule between them" )  {
+
+        MockTileMap             tileMap;
+        CollisionManager        manager( &tileMap );
+        TestCollisionListener   listener;
+        Collider                colliderA, colliderB;
+        stDimension2D           dim { { 0, 0 }, { 50, 50 } };
+
+        colliderA.SetDimension2D( dim );
+        colliderB.SetDimension2D( dim );
+
+        manager.AddCollider( 0, &colliderA );
+        manager.AddCollider( 1, &colliderB );
+        // No AddColliderToColliderRule() call.
+        manager.AddCollisionListener( &listener );
+
+        manager.Update();
+
+        CHECK( listener.colliderHits.empty() );
+    }
+
+    TEST_CASE( "RemoveCollider excludes a collider from future Update checks" )  {
+
+        MockTileMap             tileMap;
+        CollisionManager        manager( &tileMap );
+        TestCollisionListener   listener;
+        Collider                colliderA, colliderB;
+        stDimension2D           dim { { 0, 0 }, { 50, 50 } };
+
+        colliderA.SetDimension2D( dim );
+        colliderB.SetDimension2D( dim );
+
+        manager.AddCollider( 0, &colliderA );
+        manager.AddCollider( 1, &colliderB );
+        manager.AddColliderToColliderRule( 0, 1 );
+        manager.AddCollisionListener( &listener );
+
+        manager.RemoveCollider( 0, &colliderA );
+        manager.Update();
+
+        CHECK( listener.colliderHits.empty() );
+    }
+
+    TEST_CASE( "AddColliderToTileRule requires the tile layer to exist on the parent map" )  {
+
+        MockTileMap        tileMap;
+        CollisionManager   manager( &tileMap );
+
+        CHECK( manager.AddColliderToTileRule( 0, 7 ) == false );
+
+        tileMap.layersById[7] = stLayer { true, 255, { 0, 0 }, nullptr };
+
+        CHECK( manager.AddColliderToTileRule( 0, 7 ) == true );
+    }
+
+    TEST_CASE( "Update's collider-to-tile path fires nothing when TileMapToTileMatrix fails" )  {
+
+        MockTileMap             tileMap;
+        TestCollisionListener   listener;
+        Collider                collider;
+
+        tileMap.layersById[7] = stLayer { true, 255, { 0, 0 }, nullptr };
+        tileMap.bTileMapToTileMatrixResult = false;
+
+        CollisionManager  manager( &tileMap );
+
+        collider.SetDimension2D( stDimension2D { { 0, 0 }, { 32, 32 } } );
+        manager.AddCollider( 0, &collider );
+        manager.AddColliderToTileRule( 0, 7 );
+        manager.AddCollisionListener( &listener );
+
+        manager.Update();
+
+        CHECK( listener.tileHits.empty() );
+        CHECK( tileMap.nGetTileCalls == 0 );
+    }
+
+    TEST_CASE( "Update's collider-to-tile path fires nothing when GetTile fails" )  {
+
+        MockTileMap             tileMap;
+        TestCollisionListener   listener;
+        Collider                collider;
+
+        tileMap.layersById[7] = stLayer { true, 255, { 0, 0 }, nullptr };
+        tileMap.bGetTileResult = false;
+
+        CollisionManager  manager( &tileMap );
+
+        collider.SetDimension2D( stDimension2D { { 0, 0 }, { 32, 32 } } );
+        manager.AddCollider( 0, &collider );
+        manager.AddColliderToTileRule( 0, 7 );
+        manager.AddCollisionListener( &listener );
+
+        manager.Update();
+
+        CHECK( listener.tileHits.empty() );
+        CHECK( tileMap.nGetTileCalls == 1 );
+    }
+
+    TEST_CASE( "Update's collider-to-tile path reaches Hit() safely when the tile has no collision shape" )  {
+
+        MockTileMap             tileMap;
+        TestCollisionListener   listener;
+        Collider                collider;
+        tmx_tile                fakeTile {};  // zero-initialized - collision == nullptr
+
+        tileMap.layersById[7] = stLayer { true, 255, { 0, 0 }, nullptr };
+        tileMap.bGetTileResult = true;
+        tileMap.getTileResult.pTile = &fakeTile;
+        tileMap.getTileResult.dimension = stDimension2D { { 0, 0 }, { 32, 32 } };
+
+        CollisionManager  manager( &tileMap );
+
+        collider.SetDimension2D( stDimension2D { { 0, 0 }, { 32, 32 } } );
+        manager.AddCollider( 0, &collider );
+        manager.AddColliderToTileRule( 0, 7 );
+        manager.AddCollisionListener( &listener );
+
+        manager.Update();
+
+        CHECK( tileMap.nGetTileCalls == 1 );
+        CHECK( listener.tileHits.empty() );
+    }
+}


### PR DESCRIPTION
## Summary
- `tests/mock_tilemap.h` adds `MockTileMap`, a stub `ITileMap` implementing only the three methods `CollisionManager` actually calls on its parent (`GetLayer`, `TileMapToTileMatrix`, `GetTile`) with configurable results. Everything else is a trivial stub, since `CollisionManager` never reaches it - `GetInputHandler`/`GetCollisionManager` throw if called, since there's no sane mock value for either.
- `tests/test_collisionmanager.cpp` covers:
  - Layer-id validation on `AddCollider`/`AddColliderToColliderRule`/`AddColliderToTileRule`.
  - `Update()`'s collider-to-collider dispatch: fires only for overlapping colliders on a paired layer, ignores unpaired layers, respects `RemoveCollider`.
  - The collider-to-tile path's failure/no-op branches: `TileMapToTileMatrix` failing, `GetTile` failing.
  - A real, zero-initialized `tmx_tile` (`collision == nullptr`) to safely exercise `Collider::Hit(stTile&)` all the way through - that function dereferences `tile.pTile` unconditionally, so only a collision-shape-less tile (not a null `pTile`) is a valid double here.
- Updated `doc/MISSING_FEATURES.md` to reflect the closed gap.

## Test plan
- [x] `cmake --build build --target sunlight_tests` - clean build
- [x] `sunlight_tests`: 38/38 cases, 2124/2124 assertions passing (9 new `CollisionManager` cases, 17 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)