### PR TITLE
Add ScriptProcessor test coverage, fixing two real bugs found along the way

### DIFF
--- a/doc/MISSING_FEATURES.md
+++ b/doc/MISSING_FEATURES.md
@@ -50,6 +50,21 @@ which track in-engine feature/bug work.
   under its `Sprite`), so the viewport must be configured through the sprite (or on
   the texture after parenting) — configuring it on a freshly constructed,
   not-yet-added `TextureCanvas` silently targets the wrong object once it's added.
+- ~~No `ScriptProcessor` test coverage~~ — `tests/test_scriptprocessor.cpp` covers
+  queue draining, `WAIT_CMD` blocking until its delay elapses, listener dispatch
+  (and the no-listener-attached no-op case), `WAIT_SPRITES_QUEUE_EMPTY`/
+  `ResetWaitSpritesQueueEmptyCmd`, `GOTO_LABEL_CMD` backward jumps, and
+  `LOOP_CMD`/`END_LOOP_CMD` repetition. Writing these tests surfaced two real bugs,
+  both fixed:
+  - `LOOP_CMD` unconditionally reset its repeat counter to `0` every time it ran,
+    and never read `TwoParmsCommand::nParm2` (the requested repeat count) at all -
+    a loop body always ran exactly once regardless of the count passed in. Fixed
+    to seed the counter from `nParm2`.
+  - `GOTO_LABEL_CMD`/`END_LOOP_CMD` dereferenced their label lookup without
+    checking for a miss, crashing on a forward reference or a typo'd/unmatched
+    label id. Fixed to guard the lookup and report the failure through
+    `IScriptListener::OnError()` instead - previously dead code, since nothing in
+    `ScriptProcessor` ever called it.
 
 ## Missing scaffolding
 
@@ -64,13 +79,13 @@ which track in-engine feature/bug work.
 
 ## Test / sample coverage gaps
 
-- Tests cover pure-logic code (`Viewport`, `Collider`, `Helper`, `base/primitives.h`),
-  `SoundManager` (via a mock `ISound`), `TextureCanvas`, `Sprite` (both via a mock
-  `IEngine`), and `CollisionManager` (via a mock `ITileMap`, see above).
-  `TileMapRenderer` and `ScriptProcessor` still have zero test coverage -
-  `TileMapRenderer` owns its window lifecycle (`InitWindow`, `BeginDrawing`/
-  `EndDrawing`, ...) directly via raylib, so only the parts of it that route
-  through `IEngine` are unlockable via the same `MockEngine` seam, not the whole class.
+- Tests cover pure-logic code (`Viewport`, `Collider`, `Helper`, `base/primitives.h`,
+  `ScriptProcessor`), `SoundManager` (via a mock `ISound`), `TextureCanvas`, `Sprite`
+  (both via a mock `IEngine`), and `CollisionManager` (via a mock `ITileMap`, see
+  above). `TileMapRenderer` still has zero test coverage - it owns its window
+  lifecycle (`InitWindow`, `BeginDrawing`/`EndDrawing`, ...) directly via raylib, so
+  only the parts of it that route through `IEngine` are unlockable via the same
+  `MockEngine` seam, not the whole class.
 - No sample demonstrates `SoundManager` or `ScriptProcessor` (`samples/tilemaprenderer`,
   `samples/sprite`, and `samples/collision` cover map rendering, sprites/animation,
   and `CollisionManager` respectively).

--- a/src/scripting/scriptprocessor.cpp
+++ b/src/scripting/scriptprocessor.cpp
@@ -182,7 +182,16 @@ namespace SunLight {
                         case LOOP_CMD :  {
                             TwoParmsCommand   *pParm = ( TwoParmsCommand * ) *m_CurrentCommand;
 
-                            pParm -> data.nCounter = 0;
+                            /*
+                             * A jump back from END_LOOP_CMD always overshoots
+                             * this command (the unconditional m_CurrentCommand++
+                             * below runs right after the jump too), landing on
+                             * the first command of the loop body - so this case
+                             * only ever runs once per loop, and nParm2 (the
+                             * requested repeat count) only needs to seed the
+                             * counter here, never re-seed it.
+                             */
+                            pParm -> data.nCounter = pParm -> nParm2;
                             m_CommandLabelMap.insert( std ::make_pair( pParm -> nParm1, m_CurrentCommand ) );
                         }
                         break;
@@ -190,11 +199,18 @@ namespace SunLight {
                         case END_LOOP_CMD :  {
                             OneParmCommand                  *pParm     = ( OneParmCommand * ) *m_CurrentCommand;
                             CommandLabelMap :: iterator     itLoopCmd  = m_CommandLabelMap.find( pParm ->nParm );
-                            TwoParmsCommand                 *pLoopParm = ( TwoParmsCommand * ) ( *itLoopCmd -> second );
 
-                            if( pLoopParm -> data.nCounter > 0 )  {
-                                pLoopParm -> data.nCounter--;
-                                m_CurrentCommand = itLoopCmd -> second;
+                            if( itLoopCmd != m_CommandLabelMap.end() )  {
+                                TwoParmsCommand *pLoopParm = ( TwoParmsCommand * ) ( *itLoopCmd -> second );
+
+                                if( pLoopParm -> data.nCounter > 0 )  {
+                                    pLoopParm -> data.nCounter--;
+                                    m_CurrentCommand = itLoopCmd -> second;
+                                }
+                            }
+                            else if( m_pListener != nullptr )  {
+                                m_pListener -> OnError( "END_LOOP_CMD: no matching LOOP_CMD for label " +
+                                                        std :: to_string( pParm -> nParm ) );
                             }
                         }
                         break;
@@ -210,7 +226,13 @@ namespace SunLight {
                             OneParmCommand                  *pParm    = ( OneParmCommand * ) *m_CurrentCommand;
                             CommandLabelMap :: iterator     itLoopCmd = m_CommandLabelMap.find( pParm -> nParm );
 
-                            m_CurrentCommand = itLoopCmd -> second;
+                            if( itLoopCmd != m_CommandLabelMap.end() )  {
+                                m_CurrentCommand = itLoopCmd -> second;
+                            }
+                            else if( m_pListener != nullptr )  {
+                                m_pListener -> OnError( "GOTO_LABEL_CMD: unknown label " +
+                                                        std :: to_string( pParm -> nParm ) );
+                            }
                         }
                         break;
 

--- a/tests/test_scriptprocessor.cpp
+++ b/tests/test_scriptprocessor.cpp
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include <doctest/doctest.h>
+#include "scripting/scriptprocessor.h"
+#include <vector>
+#include <utility>
+
+using namespace SunLight :: Scripting;
+
+namespace  {
+
+    /**
+     * @brief Records every OnCommand()/OnError() call it receives, so tests
+     * can assert on what ScriptProcessor :: Run() actually dispatched.
+     */
+    class TestScriptListener : public IScriptListener  {
+
+        public:
+
+        std :: vector<std :: pair<Commands, uint16_t>>  commandCalls;
+        std :: vector<std :: string>                    errorCalls;
+
+        void OnCommand( Commands cmd, uint16_t nEventId )  {
+            commandCalls.push_back( { cmd, nEventId } );
+        }
+
+        void OnError( std :: string strError )  {
+            errorCalls.push_back( strError );
+        }
+    };
+}
+
+TEST_SUITE( "scripting/ScriptProcessor" )  {
+
+    TEST_CASE( "Compile fails on an empty queue and succeeds once a command is added" )  {
+
+        ScriptProcessor  sp;
+
+        CHECK( sp.Compile() == false );
+
+        sp.AddNoParmCmd( WAIT_SPRITES_QUEUE_EMPTY );
+
+        CHECK( sp.Compile() == true );
+    }
+
+    TEST_CASE( "Run drains the queue one command per call and returns false once exhausted" )  {
+
+        ScriptProcessor  sp;
+
+        sp.AddOneParmCmd( WAIT_CMD, 0 );
+        sp.AddOneParmCmd( WAIT_CMD, 0 );
+        sp.Compile();
+
+        CHECK( sp.Run() == true );
+        CHECK( sp.Run() == true );
+        CHECK( sp.Run() == false );
+    }
+
+    TEST_CASE( "Run blocks on WAIT_CMD until the requested delay elapses" )  {
+
+        TestScriptListener  listener;
+        ScriptProcessor      sp;
+
+        sp.AddOneParmCmd( WAIT_CMD, 60000 );  // 60s - never elapses during this test
+        sp.AddOneParmCmd( PLAY_SONG_CMD, 42 );
+        sp.AddScriptListener( &listener );
+        sp.Compile();
+
+        CHECK( sp.Run() == true );
+        CHECK( listener.commandCalls.empty() );
+
+        CHECK( sp.Run() == true );
+        CHECK( listener.commandCalls.empty() );
+    }
+
+    TEST_CASE( "Listener-dispatched commands forward the command and parameter" )  {
+
+        TestScriptListener  listener;
+        ScriptProcessor      sp;
+
+        sp.AddOneParmCmd( MOVE_SPRITES_TO_SCREEN_CMD, 7 );
+        sp.AddOneParmCmd( PLAY_SONG_CMD, 42 );
+        sp.AddScriptListener( &listener );
+        sp.Compile();
+
+        CHECK( sp.Run() == true );
+        CHECK( sp.Run() == true );
+
+        REQUIRE( listener.commandCalls.size() == 2 );
+        CHECK( listener.commandCalls[0] == std :: make_pair( ( Commands ) MOVE_SPRITES_TO_SCREEN_CMD, ( uint16_t ) 7 ) );
+        CHECK( listener.commandCalls[1] == std :: make_pair( ( Commands ) PLAY_SONG_CMD, ( uint16_t ) 42 ) );
+    }
+
+    TEST_CASE( "Run does not crash on a listener-dispatched command when no listener is attached" )  {
+
+        ScriptProcessor  sp;
+
+        sp.AddOneParmCmd( PLAY_SONG_CMD, 42 );
+        sp.Compile();
+
+        CHECK( sp.Run() == true );
+    }
+
+    TEST_CASE( "WAIT_SPRITES_QUEUE_EMPTY pauses the queue until ResetWaitSpritesQueueEmptyCmd is called" )  {
+
+        TestScriptListener  listener;
+        ScriptProcessor      sp;
+
+        sp.AddNoParmCmd( WAIT_SPRITES_QUEUE_EMPTY );
+        sp.AddOneParmCmd( PLAY_SONG_CMD, 42 );
+        sp.AddScriptListener( &listener );
+        sp.Compile();
+
+        CHECK( sp.Run() == true );
+        CHECK( listener.commandCalls.empty() );
+
+        // Still paused - repeated Run() calls must not advance past the wait.
+        CHECK( sp.Run() == true );
+        CHECK( listener.commandCalls.empty() );
+
+        sp.ResetWaitSpritesQueueEmptyCmd();
+
+        CHECK( sp.Run() == true );
+        REQUIRE( listener.commandCalls.size() == 1 );
+        CHECK( listener.commandCalls[0].second == 42 );
+    }
+
+    TEST_CASE( "GOTO_LABEL_CMD jumps back to a previously registered label" )  {
+
+        TestScriptListener  listener;
+        ScriptProcessor      sp;
+
+        // A label can only be jumped to once LABEL_CMD has actually run and
+        // registered it - this is a single forward pass, not a pre-scan of
+        // the whole script, so only backward jumps to already-visited
+        // labels are possible. GOTO_LABEL_CMD has no condition of its own,
+        // so this repeats indefinitely; call Run() a bounded number of times
+        // instead of draining to exhaustion.
+        sp.AddOneParmCmd( LABEL_CMD, 1 );          // 0
+        sp.AddOneParmCmd( PLAY_SONG_CMD, 42 );     // 1
+        sp.AddOneParmCmd( GOTO_LABEL_CMD, 1 );     // 2
+        sp.AddScriptListener( &listener );
+        sp.Compile();
+
+        for( int nCount = 0; nCount < 5; nCount++ )
+            CHECK( sp.Run() == true );
+
+        REQUIRE( listener.commandCalls.size() >= 2 );
+
+        for( const std :: pair<Commands, uint16_t>& call : listener.commandCalls )
+            CHECK( call.second == 42 );
+    }
+
+    TEST_CASE( "GOTO_LABEL_CMD reports an error via the listener for an unknown label instead of crashing" )  {
+
+        TestScriptListener  listener;
+        ScriptProcessor      sp;
+
+        sp.AddOneParmCmd( GOTO_LABEL_CMD, 999 );  // no matching LABEL_CMD anywhere
+        sp.AddScriptListener( &listener );
+        sp.Compile();
+
+        CHECK( sp.Run() == true );
+
+        CHECK( listener.errorCalls.size() == 1 );
+    }
+
+    TEST_CASE( "END_LOOP_CMD reports an error via the listener for an unmatched label instead of crashing" )  {
+
+        TestScriptListener  listener;
+        ScriptProcessor      sp;
+
+        sp.AddOneParmCmd( END_LOOP_CMD, 999 );  // no matching LOOP_CMD anywhere
+        sp.AddScriptListener( &listener );
+        sp.Compile();
+
+        CHECK( sp.Run() == true );
+
+        CHECK( listener.errorCalls.size() == 1 );
+    }
+
+    TEST_CASE( "LOOP_CMD/END_LOOP_CMD repeats the loop body the requested number of times" )  {
+
+        TestScriptListener  listener;
+        ScriptProcessor      sp;
+
+        sp.AddTwoParmsCmd( LOOP_CMD, /* label */ 1, /* count */ 2 );  // 0
+        sp.AddOneParmCmd( MOVE_SPRITES_TO_SCREEN_CMD, 7 );            // 1: loop body
+        sp.AddOneParmCmd( END_LOOP_CMD, /* label */ 1 );              // 2
+        sp.AddOneParmCmd( PLAY_SONG_CMD, 99 );                        // 3: after the loop
+        sp.AddScriptListener( &listener );
+        sp.Compile();
+
+        while( sp.Run() )
+            ;
+
+        // A requested count of 2 additional repeats means the body runs
+        // 3 times in total (the initial pass plus 2 jumps back).
+        REQUIRE( listener.commandCalls.size() == 4 );
+        CHECK( listener.commandCalls[0] == std :: make_pair( ( Commands ) MOVE_SPRITES_TO_SCREEN_CMD, ( uint16_t ) 7 ) );
+        CHECK( listener.commandCalls[1] == std :: make_pair( ( Commands ) MOVE_SPRITES_TO_SCREEN_CMD, ( uint16_t ) 7 ) );
+        CHECK( listener.commandCalls[2] == std :: make_pair( ( Commands ) MOVE_SPRITES_TO_SCREEN_CMD, ( uint16_t ) 7 ) );
+        CHECK( listener.commandCalls[3] == std :: make_pair( ( Commands ) PLAY_SONG_CMD, ( uint16_t ) 99 ) );
+    }
+
+    TEST_CASE( "Clear empties the queue so Compile() reports it as empty again" )  {
+
+        ScriptProcessor  sp;
+
+        sp.AddNoParmCmd( WAIT_SPRITES_QUEUE_EMPTY );
+        sp.Compile();
+
+        sp.Clear();
+
+        CHECK( sp.Compile() == false );
+    }
+
+    TEST_CASE( "AddScriptListener/GetScriptListener round-trip" )  {
+
+        TestScriptListener  listener;
+        ScriptProcessor      sp;
+
+        CHECK( sp.GetScriptListener() == nullptr );
+
+        sp.AddScriptListener( &listener );
+
+        CHECK( sp.GetScriptListener() == &listener );
+    }
+}


### PR DESCRIPTION
## Summary
- `tests/test_scriptprocessor.cpp` covers queue draining, `WAIT_CMD` blocking until its delay elapses, listener dispatch (and the no-listener-attached no-op case), `WAIT_SPRITES_QUEUE_EMPTY`/`ResetWaitSpritesQueueEmptyCmd`, `GOTO_LABEL_CMD` backward jumps, and `LOOP_CMD`/`END_LOOP_CMD` repetition.

## Two bugs found and fixed while writing the tests

1. **`LOOP_CMD` never actually looped.** It unconditionally reset `data.nCounter = 0` every time it ran, and never read `TwoParmsCommand::nParm2` (the requested repeat count) - a loop body always ran exactly once regardless of the count passed in. Traced why: a jump back from `END_LOOP_CMD` always overshoots `LOOP_CMD` itself (the unconditional `m_CurrentCommand++` right after the `switch` runs immediately after the jump too), so this case only ever executes once per loop and never needs to re-seed the counter on a revisit. Fixed to seed it from `nParm2` ([scriptprocessor.cpp](src/scripting/scriptprocessor.cpp)).
2. **`GOTO_LABEL_CMD`/`END_LOOP_CMD` crashed on an unmatched label.** Both dereferenced their `m_CommandLabelMap.find()` result without checking for `end()`. Confirmed via a real `SIGSEGV` while writing the first draft of the `GOTO_LABEL_CMD` test (which wrongly assumed a forward jump - the single-pass label registration only supports backward jumps to already-visited labels). Fixed to guard the lookup and report the failure through `IScriptListener::OnError()` - previously dead code, since nothing in `ScriptProcessor` ever called it.

`doc/MISSING_FEATURES.md` updated to reflect the closed gap and both fixes.

## Test plan
- [x] `cmake --build build --target sunlight_tests` - clean build
- [x] `sunlight_tests`: 60/60 cases, 2193/2193 assertions passing (12 new `ScriptProcessor` cases, 42 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)