### PR TITLE
Add thin TileMapRenderer test coverage for its pre-Start() contract

### DIFF
--- a/doc/MISSING_FEATURES.md
+++ b/doc/MISSING_FEATURES.md
@@ -65,6 +65,17 @@ which track in-engine feature/bug work.
     label id. Fixed to guard the lookup and report the failure through
     `IScriptListener::OnError()` instead - previously dead code, since nothing in
     `ScriptProcessor` ever called it.
+- ~~No `TileMapRenderer` test coverage~~ (partial) — `tests/test_tilemaprenderer.cpp`
+  locks in the documented pre-`Start()` contract: `LoadMap`/`AddSprite`/`RemoveSprite`
+  (which all gate on `m_bIsStarted`) and `UnloadMap`/`GetMapInfo`/`GetLayer`/`SetLayer`/
+  `TileMapToTileMatrix` (which all need a loaded `m_pTmxMap`) fail gracefully rather
+  than crash when called too early, plus `GetInputHandler`/`GetCollisionManager`
+  return stable, usable references standalone. Investigated and ruled out testing
+  the map-loading pipeline itself (parsing a real `.tmx` through a `MockEngine`,
+  no rendering needed): `LoadMap()` returns `false` immediately unless `m_bIsStarted`
+  is already `true`, which only happens after `Start()`'s real `InitWindow()` call
+  succeeds - unreachable on a headless CI runner, so that slice was scoped out
+  rather than built on a foundation that can't run in CI.
 
 ## Missing scaffolding
 
@@ -82,10 +93,11 @@ which track in-engine feature/bug work.
 - Tests cover pure-logic code (`Viewport`, `Collider`, `Helper`, `base/primitives.h`,
   `ScriptProcessor`), `SoundManager` (via a mock `ISound`), `TextureCanvas`, `Sprite`
   (both via a mock `IEngine`), and `CollisionManager` (via a mock `ITileMap`, see
-  above). `TileMapRenderer` still has zero test coverage - it owns its window
-  lifecycle (`InitWindow`, `BeginDrawing`/`EndDrawing`, ...) directly via raylib, so
-  only the parts of it that route through `IEngine` are unlockable via the same
-  `MockEngine` seam, not the whole class.
+  above). `TileMapRenderer` has only thin coverage (its pre-`Start()` guard
+  contract, see above) - the map-loading pipeline and everything past it needs a
+  real window (`Start()`'s `InitWindow()` call), so it's unreachable without a
+  display, and `Run()`'s input/update/collision dispatch loop is `private`/`inline`,
+  only reachable through that same real window loop.
 - No sample demonstrates `SoundManager` or `ScriptProcessor` (`samples/tilemaprenderer`,
   `samples/sprite`, and `samples/collision` cover map rendering, sprites/animation,
   and `CollisionManager` respectively).

--- a/tests/test_tilemaprenderer.cpp
+++ b/tests/test_tilemaprenderer.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/*
+ * TileMapRenderer's window lifecycle (Start()/Run()/Stop()) calls raylib's
+ * InitWindow()/WindowShouldClose()/BeginDrawing()/EndDrawing() directly, so
+ * it needs a real display and isn't unit-testable here (see
+ * doc/MISSING_FEATURES.md). What IS safely testable without ever calling
+ * Start(): every entry point that gates on m_bIsStarted or a loaded
+ * m_pTmxMap (LoadMap, AddSprite, RemoveSprite, GetMapInfo, GetLayer,
+ * SetLayer, TileMapToTileMatrix) is documented to fail gracefully rather
+ * than crash when called too early - this file locks that contract in,
+ * plus the handful of accessors (GetInputHandler, GetCollisionManager)
+ * that work standalone.
+ */
+
+#include <doctest/doctest.h>
+#include "renderer/tilemaprenderer.h"
+#include "sprite/sprite.h"
+
+using namespace SunLight :: Renderer;
+using namespace SunLight :: TileMap;
+
+TEST_SUITE( "renderer/TileMapRenderer" )  {
+
+    TEST_CASE( "Construction does not crash and does not start the renderer" )  {
+
+        TileMapRenderer  renderer( 800, 600, "test", -1, true );
+        stMapInfo        mapInfo;
+
+        CHECK( renderer.GetMapInfo( mapInfo ) == false );
+    }
+
+    TEST_CASE( "GetInputHandler returns the same handler instance on every call" )  {
+
+        TileMapRenderer  renderer( 800, 600, "test", -1, false );
+
+        CHECK( &renderer.GetInputHandler() == &renderer.GetInputHandler() );
+    }
+
+    TEST_CASE( "GetCollisionManager returns a stable, usable reference before any map is loaded" )  {
+
+        TileMapRenderer  renderer( 800, 600, "test", -1, false );
+
+        CHECK( &renderer.GetCollisionManager() == &renderer.GetCollisionManager() );
+
+        // AddColliderToColliderRule only touches the collider-layer lists,
+        // not the parent tile map, so it works even with nothing loaded.
+        CHECK( renderer.GetCollisionManager().AddColliderToColliderRule( 0, 1 ) == true );
+    }
+
+    TEST_CASE( "LoadMap fails without crashing when the renderer hasn't been started" )  {
+
+        TileMapRenderer  renderer( 800, 600, "test", -1, false );
+
+        CHECK( renderer.LoadMap( "does-not-matter.tmx" ) == false );
+    }
+
+    TEST_CASE( "UnloadMap/GetMapInfo report failure when no map has been loaded" )  {
+
+        TileMapRenderer  renderer( 800, 600, "test", -1, false );
+        stMapInfo        mapInfo;
+
+        CHECK( renderer.UnloadMap() == false );
+        CHECK( renderer.GetMapInfo( mapInfo ) == false );
+    }
+
+    TEST_CASE( "GetLayer/SetLayer (by id and by name) report failure when no map has been loaded" )  {
+
+        TileMapRenderer  renderer( 800, 600, "test", -1, false );
+        stLayer          layer {};
+
+        CHECK( renderer.GetLayer( 1, layer ) == false );
+        CHECK( renderer.GetLayer( "layer1", layer ) == false );
+        CHECK( renderer.SetLayer( 1, layer ) == false );
+        CHECK( renderer.SetLayer( "layer1", layer ) == false );
+    }
+
+    TEST_CASE( "TileMapToTileMatrix reports failure when no map has been loaded" )  {
+
+        TileMapRenderer   renderer( 800, 600, "test", -1, false );
+        stCoordinate2D    coord { 0, 0 };
+        stMatrixPosition  pos   { 0, 0 };
+
+        CHECK( renderer.TileMapToTileMatrix( coord, pos ) == false );
+    }
+
+    TEST_CASE( "AddSprite/RemoveSprite report failure when the renderer hasn't been started" )  {
+
+        TileMapRenderer                    renderer( 800, 600, "test", -1, false );
+        SunLight :: Sprite :: Sprite       sprite;
+
+        CHECK( renderer.AddSprite( 1, sprite ) == false );
+        CHECK( renderer.RemoveSprite( 1, sprite ) == false );
+    }
+}


### PR DESCRIPTION
## Summary
- `tests/test_tilemaprenderer.cpp` covers what's actually reachable without a real window: `LoadMap`/`AddSprite`/`RemoveSprite` (gated on `m_bIsStarted`) and `UnloadMap`/`GetMapInfo`/`GetLayer`/`SetLayer`/`TileMapToTileMatrix` (gated on a loaded `m_pTmxMap`) fail gracefully rather than crash when called too early, and `GetInputHandler`/`GetCollisionManager` return stable, usable references standalone (the latter demonstrated via a real `AddColliderToColliderRule` call, since that doesn't need a parent map).

## Scope note
I investigated testing the map-loading pipeline itself (parsing a real `.tmx` fixture through the `MockEngine` seam from #54, no rendering needed) but ruled it out: `LoadMap()` returns `false` immediately unless `m_bIsStarted` is already `true`, and that's only ever set inside `Start()` after a real `InitWindow()` call succeeds - unreachable on a headless CI runner. Rather than build a test plan on a foundation that can't actually run in CI, I scoped this down to the pre-`Start()` guard contract, which is genuinely useful ("what happens if I call X before Y" is exactly the kind of boundary behavior a library consumer needs to be able to rely on) and documented the reasoning in `doc/MISSING_FEATURES.md`.

## Test plan
- [x] `cmake --build build --target sunlight_tests` - clean build
- [x] `sunlight_tests`: 68/68 cases, 2207/2207 assertions passing (8 new `TileMapRenderer` cases, 14 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)