### PR TITLE
Add CONTRIBUTING.md, SECURITY.md, and CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,96 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project has not yet made a tagged release; version numbers will start
+once `0.1.0` ships.
+
+This changelog starts from the point the project adopted the practices
+described in `CLAUDE.md` (backend abstraction, CI, unit tests). Earlier
+history (2021–2023, the project's early prototyping phase) isn't itemized
+here — see the git log for that period.
+
+## [Unreleased]
+
+### Added
+
+- `IEngine` backend abstraction (`src/engines/`) — all raylib draw calls now
+  go through a swappable interface + `EngineFactory`, instead of raylib types
+  leaking into `TextureCanvas`/`TileMapRenderer` headers.
+- `IEngine::GetApplicationDirectory()` for resolving resource paths relative
+  to the running executable instead of a hardcoded, machine-specific path.
+- `TileMapRenderer::SetWindowTitle()` for changing the window title after
+  construction.
+- Right-stick analog handling for `GAMEPAD_BUTTON_RIGHT_FACE_*` events,
+  mirroring the existing left-stick → `LEFT_FACE_*` virtual DPad dispatch.
+- `samples/collision` — demonstrates `CollisionManager`, `AddColliderToColliderRule`,
+  and the `ICollisionListener` callback with a player-controlled sprite.
+- `samples/gamepad` — demonstrates independent left/right analog stick control
+  of two separate sprites on one connected gamepad.
+- GitHub Actions CI (`.github/workflows/ci.yml`) building the library, both
+  samples, and the test suite on Linux, macOS, and Windows on every push and
+  PR against `main`; the three `build (<os>)` jobs are required status checks.
+- Unit test suite (`tests/`, via [doctest](https://github.com/doctest/doctest)),
+  covering:
+  - Pure logic: `Viewport`, `Collider`, `Helper`, `base/primitives.h`.
+  - `SoundManager`, via `SoundFactory::SetCreator()` and a `MockSound` test
+    double — no real audio device involved.
+  - `TextureCanvas` and `Sprite`, via `EngineFactory::SetEngine()` and a
+    `MockEngine` test double — no real window/render context involved.
+  - `CollisionManager`, via a `MockTileMap` test double.
+  - `ScriptProcessor`, covering command queue draining, listener dispatch,
+    `WAIT_CMD`/`WAIT_SPRITES_QUEUE_EMPTY` blocking, and `LOOP_CMD`/
+    `GOTO_LABEL_CMD` control flow.
+  - `TileMapRenderer`'s pre-`Start()` contract (the parts reachable without a
+    real window).
+- `SoundFactory`/`EngineFactory::SetEngine()` test-only override hooks, giving
+  `SoundManager`/anything routing through `IEngine` a seam to substitute a
+  mock backend.
+- `cmake --install` now generates a real `sunlightConfig.cmake`/
+  `sunlightConfigVersion.cmake` and installs the `sunlight` target, its
+  headers, and the vendored `raylib`/`tmx` runtime libs.
+- `doc/MISSING_FEATURES.md` tracking project-level gaps (scaffolding, CI,
+  test/sample coverage) as they're found and closed.
+- Real usage docs for the `sprite` and `tilemaprenderer` samples (previously
+  stub placeholders).
+
+### Changed
+
+- `libxml2` and `tmx` dependencies pinned to stable release tags
+  (`v2.15.3`/`tmx_1.10.1`), matching `raylib` (`5.5`), instead of tracking
+  `master`.
+- Internal containers/members that exclusively own heap-allocated data
+  converted from raw `new`/`delete` to `std::unique_ptr` throughout the
+  library (`Sprite::m_Sequences`, `CollisionManager`'s rule lists,
+  `SoundManager::m_SoundMap`, `TileMapRenderer`'s input handler and event
+  handler lists, and others).
+- VSCode sample settings use the `VCPKG_ROOT` environment variable instead of
+  a hardcoded vcpkg path.
+
+### Fixed
+
+- Broken `install()` rule — `cmake --install` previously produced a package
+  config that couldn't actually be consumed.
+- `sunlightConfig.cmake.in` path resolution when `sunlight` is consumed via
+  `FetchContent` from another project (was using `CMAKE_SOURCE_DIR` instead of
+  `CMAKE_CURRENT_SOURCE_DIR`).
+- `TextureCanvas::Load()`'s auto-size-on-load guard checked
+  `dimension.size.nHeight == 0` twice instead of checking `nWidth` and
+  `nHeight` — harmless when both start at zero (the common case), but it
+  could silently clobber a caller-set width if only height was left at zero.
+- `ScriptProcessor`'s `LOOP_CMD` unconditionally reset its repeat counter to
+  `0` on every run and never read the requested repeat count at all — a loop
+  body always ran exactly once regardless of the count passed in.
+- `ScriptProcessor`'s `GOTO_LABEL_CMD`/`END_LOOP_CMD` dereferenced their label
+  lookup without checking for a miss, crashing on a forward reference or a
+  typo'd/unmatched label id. Now reports the failure through
+  `IScriptListener::OnError()` instead.
+- A dead `HandleGamePadEvent` declaration with no implementation, left over
+  from an earlier refactor.
+- `SunLight::Input::KeyboardKey` vs. raylib's own global `KeyboardKey` name
+  collision in `TileMapRenderer::SetExitKey`.
+
+### Removed
+
+- Nothing yet.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to sunlight
+
+Thanks for your interest in contributing! This document covers the practical
+steps for building, testing, and submitting changes.
+
+## Building
+
+Requires CMake 3.24+ and system zlib. Unless `-DUSE_LOCAL_LIBXML2` is passed,
+libxml2/raylib/tmx are fetched automatically via `FetchContent`. See the
+[README](README.md#requirements-memo) for platform-specific dependency setup
+(vcpkg on Windows, raylib's own Linux dependencies, etc.).
+
+```shell
+cmake -B build -S .
+cmake --build build --target sunlight -j 4
+```
+
+To build the samples and/or run the test suite locally:
+
+```shell
+cmake -B build -S . -DBUILD_LIBRARY_SAMPLES=ON -DBUILD_LIBRARY_TESTS=ON
+cmake --build build -j 4
+ctest --test-dir build
+```
+
+`src/CMakeLists.txt` globs all `.cpp`/`.h` files under `src/` recursively — after
+adding a new source file, re-run `cmake -B build -S .` so the glob picks it up.
+
+## Before submitting a PR
+
+- **Run the test suite** (`ctest --test-dir build` or
+  `./build/tests/sunlight_tests`) and confirm it's still green. Add test
+  coverage for new logic where practical — see `tests/mock_engine.h`,
+  `tests/mock_sound.h`, and `tests/mock_tilemap.h` for the mocking seams
+  (`EngineFactory::SetEngine()`, `SoundFactory::SetCreator()`) already
+  available for code that touches `IEngine`/`ISound`.
+- **Reset `BUILD_LIBRARY_SAMPLES`/`BUILD_LIBRARY_TESTS` to `OFF`** before
+  committing if you turned them on locally — they default to `OFF` and PRs
+  shouldn't change that.
+- Keep commits focused; a bug fix doesn't need an unrelated refactor riding
+  along with it.
+
+## Code conventions
+
+These are the patterns the existing code already follows — matching them keeps
+the codebase consistent:
+
+- **One namespace per module**, mirroring the directory layout:
+  `SunLight::<Module>` (e.g. `SunLight::Renderer`, `SunLight::Collision`).
+- **Backend abstraction pattern**: any subsystem that touches raylib directly
+  follows the shape `IThing` (interface) + `ThingFactory` (owns the one
+  `#if DEFAULT_ENGINE == 1 ... #else #error` switch) + `thing/raylib/RaylibThing`
+  (concrete implementation). See `IEngine`/`EngineFactory` as the reference
+  instance of this pattern. Call sites elsewhere should never need raylib types
+  directly.
+- **Pointer ownership**: containers/members that exclusively own heap-allocated
+  data use `std::unique_ptr`, not raw `new`/`delete`. Raw pointers are reserved
+  for genuinely non-owning references (back-pointers, externally-owned objects
+  registered into a manager, handles crossing a C API boundary like tmx
+  callbacks). When adding a new owning member, prefer `unique_ptr`.
+- **Native geometry/texture types**: prefer `base/primitives.h`'s
+  `stRectangle`/`stVector2D`/`TextureHandle` over raylib's own `Rectangle`/
+  `Vector2`/`Texture2D` in new backend-agnostic code.
+- **`SunLight::Input::KeyboardKey` gotcha**: it's a distinct enum from raylib's
+  own global `KeyboardKey`, with matching numeric values but no
+  `using namespace SunLight::Input`. An unqualified `KeyboardKey` inside
+  `namespace SunLight::Renderer` silently resolves to whichever one happens to
+  be visible via prior `#include`s. Always fully qualify as
+  `SunLight::Input::KeyboardKey` in new code.
+
+See `CLAUDE.md` for the full architecture writeup (module map, known issues,
+git workflow) if you're making a larger change.
+
+## Submitting changes
+
+1. Fork the repository (or push a branch directly if you have write access).
+2. Open a pull request against `main` describing what changed and why.
+3. Make sure the CI checks (`build (ubuntu-latest)`, `build (macos-latest)`,
+   `build (windows-latest)`) pass — they build the library, both samples, and
+   the test suite on all three platforms.
+4. `main` requires at least one approving review before merging.
+
+## Reporting bugs / requesting features
+
+Open a GitHub issue. For security vulnerabilities, see [SECURITY.md](SECURITY.md)
+instead — please don't report those in a public issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+`sunlight` has not yet had a tagged release (it's currently pre-`0.1.0`). Security
+fixes are made against `main`, which is the only branch supported at this time.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Instead, use GitHub's private vulnerability reporting:
+
+1. Go to the [Security tab](https://github.com/popolony2k/sunlight/security) of this repository.
+2. Click **"Report a vulnerability"**.
+3. Describe the issue, including steps to reproduce it and its potential impact.
+
+This opens a private advisory visible only to the maintainers until a fix is
+ready, so details aren't disclosed before users can update.
+
+You can expect an initial response within a few days. If the report is confirmed,
+we'll work with you on a fix and coordinate disclosure timing before any public
+advisory or release is published.
+
+## Scope
+
+`sunlight` is a game engine library that wraps [raylib](https://www.raylib.com/)
+and [libtmx](https://github.com/baylej/tmx.git). Vulnerabilities in those upstream
+projects should generally be reported to them directly, unless `sunlight`'s own
+code introduces or amplifies the issue (e.g. unsafe handling of a loaded map or
+asset file).

--- a/doc/MISSING_FEATURES.md
+++ b/doc/MISSING_FEATURES.md
@@ -76,13 +76,19 @@ which track in-engine feature/bug work.
   is already `true`, which only happens after `Start()`'s real `InitWindow()` call
   succeeds - unreachable on a headless CI runner, so that slice was scoped out
   rather than built on a foundation that can't run in CI.
+- ~~No `CONTRIBUTING.md`, `SECURITY.md`, or `CHANGELOG.md`~~ — `CONTRIBUTING.md`
+  covers building/testing, the code conventions from `CLAUDE.md`, and the PR
+  workflow. `SECURITY.md` points reporters at GitHub's private vulnerability
+  reporting (enabled on the repo as part of this change) instead of a public
+  issue. `CHANGELOG.md` follows Keep a Changelog, starting from the point the
+  project adopted these practices (`main` is unreleased, so everything so far
+  lives under `[Unreleased]`).
 
 ## Missing scaffolding
 
 - No git tags/releases yet — `project(sunlight VERSION 0.1.0)` exists now (added
   while fixing the `install()` rule), but there's still no tagged release, so
   there's no way to tell a consumer "you're on v0.x" from git history alone.
-- No `CONTRIBUTING.md`, `SECURITY.md`, or `CHANGELOG.md`.
 - No Doxygen config. Every header already uses consistent `@brief`/`@param`
   doxygen-style comments, but none of it is ever rendered into browsable docs.
 - No `.gitattributes`, despite the project explicitly supporting


### PR DESCRIPTION
## Summary
- `CONTRIBUTING.md` — building/testing steps, the code conventions already documented in `CLAUDE.md` (backend abstraction pattern, pointer ownership, the `KeyboardKey` gotcha), and the PR workflow.
- `SECURITY.md` — points reporters at GitHub's private vulnerability reporting instead of a public issue. I enabled that feature on the repo as part of this change (it was off), since pointing the doc at a disabled feature would be misleading.
- `CHANGELOG.md` — follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). `main` has no tagged release yet, so everything so far lives under `[Unreleased]`; starts from the point the project adopted the practices described in `CLAUDE.md` (backend abstraction, CI, unit tests) rather than itemizing the earlier 2021-2023 prototyping history.
- `doc/MISSING_FEATURES.md` updated to reflect this gap closed.

## Test plan
- Docs-only change, no code touched - nothing to build/test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)