### PR TITLE
Move API documentation link into the README's Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,10 @@
 `sunlight` is an open source library written in C++ to make 2D games. Overall, its present main features include a manager that can deal with map, collision, sprites and graphic primitives.
 
 [raylib](https://www.raylib.com/) was used for graphic backend, but the project aims to be extended to SDL and many others. Rendering is exposed through an `IEngine` interface (`src/engines/`) so a new backend only needs its own implementation plus one line in the engine factory, without touching the rest of the codebase.
-
-📖 [API documentation](https://popolony2k.github.io/sunlight/) (generated with Doxygen)
 </div>
 
 ## Table of Contents :pushpin:
+* [API documentation](https://popolony2k.github.io/sunlight/) :book:
 * [Requirements](#requirements-memo)
     - [CMake 3.24](#cmake-324)
     - [vcpkg](#vcpkg-windows-only)


### PR DESCRIPTION
## Summary
- Moves the Doxygen API docs link (added in #60) from the header prose into the Table of Contents, where it reads better alongside the other section links.

## Test plan
- Docs-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)