### PR TITLE
Add .gitattributes for cross-platform line-ending normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,35 @@
+# Auto-detect text files and normalize line endings to LF in the repository,
+# regardless of what line endings a contributor's OS/editor writes.
+* text=auto eol=lf
+
+# Source code
+*.cpp text
+*.h   text
+*.in  text
+
+# Build/config files
+*.txt       text
+*.cmake     text
+Doxyfile    text
+LICENSE     text
+.gitignore  text
+.gitattributes text
+
+# Docs
+*.md text
+
+# Tiled map/tileset files (XML) and their legacy/backup copies
+*.tmx     text
+*.tsx     text
+*.tmx.old text
+*.tsx.old text
+
+# Misc text formats
+*.json text
+*.yml  text
+
+# Images - binary, never line-ending-normalize or diff as text
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.ico binary

--- a/doc/MISSING_FEATURES.md
+++ b/doc/MISSING_FEATURES.md
@@ -97,8 +97,12 @@ which track in-engine feature/bug work.
   (stale `@param` names after refactors, a stray `@ITileMapListener`/`\The`
   typo, a couple of unresolved `\link` targets) show up as Doxygen warnings
   but don't block generation — left as-is, not in scope here.
-- No `.gitattributes`, despite the project explicitly supporting
-  Windows/Mac/Linux — no line-ending normalization across platforms.
+- ~~No `.gitattributes`~~ — normalizes text files (source, CMake, Tiled maps/
+  tilesets, docs, config) to LF in the repository regardless of a
+  contributor's OS/editor, and marks images (`.png`/`.jpg`/`.ico`) binary so
+  Git never line-ending-normalizes or text-diffs them. No tracked file had
+  CRLF endings at the time this was added, so no renormalization commit was
+  needed.
 
 ## Test / sample coverage gaps
 


### PR DESCRIPTION
## Summary
- Adds `.gitattributes`: normalizes source (`.cpp`/`.h`), CMake, Tiled map/tileset (`.tmx`/`.tsx`), docs, and config files to LF regardless of a contributor's OS/editor, and marks images (`.png`/`.jpg`/`.ico`) binary so Git never line-ending-normalizes or text-diffs them.
- Checked first: no tracked file currently has CRLF endings (`file` on every tracked path came back clean), so this doesn't need a renormalization commit alongside it.
- `doc/MISSING_FEATURES.md` updated to reflect the closed gap.

## Test plan
- Repo config change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)