### PR TITLE
Add tag-triggered release workflow (build, package, publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux-x64
+            archive_ext: tar.gz
+          - os: macos-latest
+            platform: macos
+            archive_ext: tar.gz
+          - os: windows-latest
+            platform: windows-x64
+            archive_ext: zip
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            zlib1g-dev \
+            libasound2-dev \
+            libx11-dev \
+            libxrandr-dev \
+            libxi-dev \
+            libgl1-mesa-dev \
+            libglu1-mesa-dev \
+            libxcursor-dev \
+            libxinerama-dev \
+            libwayland-dev \
+            libxkbcommon-dev
+
+      - name: Install Windows dependencies (zlib, iconv via vcpkg)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: vcpkg install zlib:x64-windows libiconv:x64-windows
+
+      - name: Configure (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: cmake -B build -S . -DBUILD_LIBRARY_SAMPLES=OFF -DBUILD_LIBRARY_TESTS=OFF -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/sunlight-${{ github.ref_name }}-${{ matrix.platform }} -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+
+      - name: Configure (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: cmake -B build -S . -DBUILD_LIBRARY_SAMPLES=OFF -DBUILD_LIBRARY_TESTS=OFF "-DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/sunlight-${{ github.ref_name }}-${{ matrix.platform }}" "-DCMAKE_POLICY_VERSION_MINIMUM=3.5" "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+
+      - name: Build
+        run: cmake --build build --target sunlight --config Release -j 4
+
+      - name: Install
+        run: cmake --install build --config Release
+
+      - name: Package (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: tar -czf sunlight-${{ github.ref_name }}-${{ matrix.platform }}.tar.gz sunlight-${{ github.ref_name }}-${{ matrix.platform }}
+
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Compress-Archive -Path sunlight-${{ github.ref_name }}-${{ matrix.platform }} -DestinationPath sunlight-${{ github.ref_name }}-${{ matrix.platform }}.zip
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sunlight-${{ matrix.platform }}
+          path: sunlight-${{ github.ref_name }}-${{ matrix.platform }}.${{ matrix.archive_ext }}
+          if-no-files-found: error
+
+  release:
+    needs: package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all platform artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" dist/* \
+            --title "sunlight ${{ github.ref_name }}" \
+            --generate-notes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,27 @@ git workflow) if you're making a larger change.
    the test suite on all three platforms.
 4. `main` requires at least one approving review before merging.
 
+## Releasing
+
+Releases are cut by pushing a tag — nothing else is needed:
+
+```shell
+git tag v0.2.0
+git push origin v0.2.0
+```
+
+Pushing a tag matching `v*` triggers `.github/workflows/release.yml`, which builds and
+`cmake --install`s the library (headers + shared libs, no samples/tests) on Linux, macOS, and
+Windows, packages each as `sunlight-vX.Y.Z-<platform>.{tar.gz,zip}`, and publishes a GitHub
+Release with those three archives attached and release notes generated automatically from the
+PRs merged since the previous tag.
+
+The version number itself is a manual choice (this project isn't on automated/Conventional-Commit
+versioning) — follow [Semantic Versioning](https://semver.org/): bump `PATCH` for fixes, `MINOR`
+for new features (the project hasn't reached `1.0.0` yet, so breaking changes also bump `MINOR`
+per semver's pre-1.0 convention), and update `project(sunlight VERSION X.Y.Z)` in
+`src/CMakeLists.txt` to match before tagging.
+
 ## Reporting bugs / requesting features
 
 Open a GitHub issue. For security vulnerabilities, see [SECURITY.md](SECURITY.md)

--- a/doc/MISSING_FEATURES.md
+++ b/doc/MISSING_FEATURES.md
@@ -86,9 +86,18 @@ which track in-engine feature/bug work.
 
 ## Missing scaffolding
 
-- No git tags/releases yet — `project(sunlight VERSION 0.1.0)` exists now (added
-  while fixing the `install()` rule), but there's still no tagged release, so
-  there's no way to tell a consumer "you're on v0.x" from git history alone.
+- ~~No git tags/releases~~ — `.github/workflows/release.yml` triggers on any `v*` tag push,
+  builds and `cmake --install`s the library on Linux/macOS/Windows (headers + shared libs, no
+  samples/tests), packages each platform as `sunlight-vX.Y.Z-<platform>.{tar.gz,zip}`, and
+  publishes a GitHub Release with all three attached and auto-generated notes. The version number
+  itself stays a manual, deliberate choice (see `CONTRIBUTING.md`'s "Releasing" section) rather
+  than fully automated Conventional-Commit-driven versioning — investigated that route too, but
+  `main`'s branch ruleset only allows pull-request-based bypass (confirmed via `gh api
+  repos/.../rulesets`), so a tool that wants to push a version-bump/changelog commit directly to
+  `main` (the classic `semantic-release` + `@semantic-release/git` setup) can't work here without
+  weakening branch protection. Tags and GitHub Releases aren't subject to that ruleset at all
+  (it's scoped to `target: "branch"`), which is what makes the tag-triggered build/package/publish
+  flow here fully automatic with zero protection changes.
 - ~~No Doxygen config~~ — `Doxyfile` (root) generates HTML from `src/` (with
   `README.md` as the main page), published via `.github/workflows/doxygen.yml`
   to GitHub Pages on every push to `main`. Live at


### PR DESCRIPTION
## Summary
- New `.github/workflows/release.yml`: pushing a `v*` tag builds and `cmake --install`s the library (headers + shared libs, no samples/tests) on Linux/macOS/Windows, packages each as `sunlight-vX.Y.Z-<platform>.{tar.gz,zip}`, and publishes a GitHub Release with all three attached plus auto-generated notes (PRs merged since the previous tag).
- Verified the exact configure/build/install/package sequence locally end-to-end before writing the YAML (confirmed `libsunlight` + its raylib/tmx/libxml2 deps + headers + `sunlightConfig.cmake` all land correctly under a single top-level `sunlight-vX.Y.Z-<platform>/` folder in the archive).
- `CONTRIBUTING.md` gains a "Releasing" section documenting the `git tag vX.Y.Z && git push origin vX.Y.Z` flow and semver guidance.
- `doc/MISSING_FEATURES.md` updated - this closes the last item on the scaffolding list.

## Why not fully automated (Conventional-Commit-driven) versioning
Looked into this too: `main`'s branch ruleset (`gh api repos/popolony2k/sunlight/rulesets/3548330`) only allows a **pull-request-based** bypass, so a `semantic-release` + `@semantic-release/git`-style setup that wants to push a version-bump/changelog commit directly to `main` can't work here without weakening branch protection. Tags and GitHub Releases aren't covered by that ruleset at all (it's scoped to `target: "branch"`), which is exactly what makes the tag-triggered flow in this PR fully automatic with zero protection changes. Version numbers stay a manual, deliberate choice - a `release-please`-style PR-based approach would get fully automated versioning too, noted as a possible future upgrade but out of scope here.

## Test plan
- [x] Local dry run of the full configure → build → install → package sequence (matching the workflow's exact CMake invocations) - produces a correct, working archive
- [ ] This PR's own CI (`build (ubuntu-latest/macos-latest/windows-latest)`) - the release workflow itself only triggers on tag push, so it won't run against this PR; will verify by cutting an actual tag after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)