### PR TITLE
Add TileMapRenderer::SetScreenFade() and SoundManager::SetVolume()

### DIFF
--- a/src/renderer/tilemaprenderer.cpp
+++ b/src/renderer/tilemaprenderer.cpp
@@ -1073,6 +1073,7 @@ namespace SunLight {
             m_fWindowHeight               = fHeight;
             m_nTargetFps                  = nTargetFps;
             m_strTitle                    = szTitle;
+            m_fScreenFadeAlpha            = 0.0f;
             m_pTmxMap                     = NULL;
             m_bIsStarted                  = false;
             m_bWindowResizeable           = __DEFAULT_RESIZEABLE_STATUS;
@@ -1381,6 +1382,16 @@ namespace SunLight {
 
             if( m_bIsStarted )
                 :: SetWindowTitle( m_strTitle.c_str() );
+        }
+
+        /**
+         * @brief Set a whole-screen fade overlay. Stored here and drawn by
+         * @see Run() as the very last thing each frame, on top of whatever
+         * else was rendered - see Run()'s own comment for why.
+         */
+        void TileMapRenderer :: SetScreenFade( float fAlpha )  {
+
+            m_fScreenFadeAlpha = fAlpha;
         }
 
         /**
@@ -1767,7 +1778,29 @@ namespace SunLight {
                         HandleUserInput();
                         HandleUserUpdate();
                         HandleUserCollisions();
+
+                        /*
+                         * Screen fade overlay - drawn last, after
+                         * everything else this frame, so it composites on
+                         * top of the whole rendered scene rather than any
+                         * single element. Deliberately inside the
+                         * GetVisible() branch: if nothing was rendered this
+                         * frame, there's nothing fresh to composite over -
+                         * drawing it unconditionally would paint over
+                         * whatever stale content is still in the frame
+                         * buffer from the last visible frame instead. Uses
+                         * raylib's own ::DrawRectangle/::Fade directly
+                         * (this class already has its own, unrelated,
+                         * wireframe-only DrawRectangle method, hence the ::
+                         * qualification - same idiom as ::SetWindowTitle
+                         * above).
+                         */
+                        if( m_fScreenFadeAlpha > 0.0f )  {
+                            :: DrawRectangle( 0, 0, ( int ) m_fWindowWidth, ( int ) m_fWindowHeight,
+                                             :: Fade( BLACK, m_fScreenFadeAlpha ) );
+                        }
                     }
+
                     EndDrawing();
                 }
 

--- a/src/renderer/tilemaprenderer.h
+++ b/src/renderer/tilemaprenderer.h
@@ -101,6 +101,7 @@ namespace SunLight {
             uint32_t                                   m_nWindowBackgroundColor;
             __AnimInfoList                             m_AnimInfoList;
             std :: string                              m_strTitle;
+            float                                      m_fScreenFadeAlpha;
             tmx_map                                    *m_pTmxMap;
             bool                                       m_bClearBackground;
             bool                                       m_bIsStarted;
@@ -245,6 +246,7 @@ namespace SunLight {
 
             // Window management
             void SetWindowTitle( const std :: string &strTitle );
+            void SetScreenFade( float fAlpha );
 
             // Layer management
             bool SetLayer( int nLayerId, SunLight :: TileMap :: stLayer& layer );

--- a/src/sound/isound.h
+++ b/src/sound/isound.h
@@ -97,6 +97,17 @@ namespace SunLight {
              * @return false If is not playing;
              */
             virtual bool IsPlaying( void ) = 0;
+
+            /**
+             * @brief Must be implemented to set this sound's playback volume
+             * on chosen target engine, independently of every other loaded
+             * sound;
+             *
+             * @param fVolume Volume level, 0.0 (silent) to 1.0 (max);
+             * @return true If operation was succesfull;
+             * @return false If operation was failed;
+             */
+            virtual bool SetVolume( float fVolume ) = 0;
         };
     }
 }

--- a/src/sound/raylib/raylibsound.cpp
+++ b/src/sound/raylib/raylibsound.cpp
@@ -190,6 +190,24 @@ namespace SunLight {
 
                 return false;
             }
+
+            /**
+             * @brief Implements per-sound volume control on chosen target
+             * engine;
+             *
+             * @param fVolume Volume level, 0.0 (silent) to 1.0 (max);
+             * @return true If operation was succesfull;
+             * @return false If operation was failed;
+             */
+            bool RayLibSound :: SetVolume( float fVolume )  {
+
+                if( m_Loaded )  {
+                    ::SetSoundVolume( m_Sound, fVolume );
+                    return true;
+                }
+
+                return false;
+            }
         }
     }
 }

--- a/src/sound/raylib/raylibsound.h
+++ b/src/sound/raylib/raylibsound.h
@@ -55,6 +55,7 @@ namespace SunLight {
                 bool Pause( void );
                 bool Resume( void );
                 bool IsPlaying( void );
+                bool SetVolume( float fVolume );
             };
         }
     }

--- a/src/sound/soundmanager.cpp
+++ b/src/sound/soundmanager.cpp
@@ -175,5 +175,25 @@ namespace SunLight {
 
             return bRet;
         }
+
+        /**
+         * @brief Set a loaded sound's playback volume, independently of
+         * every other loaded sound;
+         *
+         * @param nSoundId The corresponding sound id loaded by @see Load function;
+         * @param fVolume Volume level, 0.0 (silent) to 1.0 (max);
+         * @return true If operation was succesfull;
+         * @return false If operation was failed;
+         */
+        bool SoundManager :: SetVolume( int nSoundId, float fVolume )  {
+
+            std :: map<int, std :: unique_ptr<ISound>> :: iterator itItem = m_SoundMap.find( nSoundId );
+            bool    bRet = false;
+
+            if( itItem != m_SoundMap.end() )
+                bRet = itItem -> second -> SetVolume( fVolume );
+
+            return bRet;
+        }
     }
 }

--- a/src/sound/soundmanager.h
+++ b/src/sound/soundmanager.h
@@ -51,6 +51,7 @@ namespace SunLight {
             bool Pause( int nSoundId );
             bool Resume( int nSoundId );
             bool IsPlaying( int nSoundId );
+            bool SetVolume( int nSoundId, float fVolume );
         };
     }
 }

--- a/src/tilemap/itilemap.h
+++ b/src/tilemap/itilemap.h
@@ -137,6 +137,16 @@ namespace SunLight {
             virtual void SetWindowTitle( const std :: string &strTitle ) = 0;
 
             /**
+             * @brief Set a whole-screen fade overlay, drawn on top of every
+             * other rendered element (tilemap, sprites, everything) - not a
+             * per-texture effect.
+             *
+             * @param fAlpha Fade amount, 0.0 (fully visible, no overlay) to
+             * 1.0 (fully black);
+             */
+            virtual void SetScreenFade( float fAlpha ) = 0;
+
+            /**
              * Set layer parameters.
              * @param nLayerId The layer id to set layer parameters;
              * @param layer reference to layer parameters structure to set;

--- a/tests/mock_sound.h
+++ b/tests/mock_sound.h
@@ -41,6 +41,7 @@ class MockSound : public SunLight :: Sound :: ISound  {
     bool          bPauseResult     = true;
     bool          bResumeResult    = true;
     bool          bIsPlayingResult = false;
+    bool          bSetVolumeResult = true;
 
     int           nLoadCalls      = 0;
     int           nUnloadCalls    = 0;
@@ -49,6 +50,9 @@ class MockSound : public SunLight :: Sound :: ISound  {
     int           nPauseCalls     = 0;
     int           nResumeCalls    = 0;
     int           nIsPlayingCalls = 0;
+    int           nSetVolumeCalls = 0;
+
+    float         fLastVolume     = 0.0f;
 
     std :: string strLastFileName;
 
@@ -86,6 +90,12 @@ class MockSound : public SunLight :: Sound :: ISound  {
     bool IsPlaying( void )  {
         nIsPlayingCalls++;
         return bIsPlayingResult;
+    }
+
+    bool SetVolume( float fVolume )  {
+        nSetVolumeCalls++;
+        fLastVolume = fVolume;
+        return bSetVolumeResult;
     }
 };
 

--- a/tests/mock_tilemap.h
+++ b/tests/mock_tilemap.h
@@ -65,6 +65,7 @@ class MockTileMap : public SunLight :: TileMap :: ITileMap  {
     void MoveCameraLeft( void )  {}
     void MoveCameraRight( void )  {}
     void SetWindowTitle( const std :: string& )  {}
+    void SetScreenFade( float )  {}
 
     bool SetLayer( int, SunLight :: TileMap :: stLayer& )  {
         return false;

--- a/tests/test_soundmanager.cpp
+++ b/tests/test_soundmanager.cpp
@@ -79,6 +79,19 @@ TEST_SUITE( "sound/SoundManager" )  {
         CHECK( fixture.pLastCreated -> nIsPlayingCalls == 1 );
     }
 
+    TEST_CASE( "SetVolume forwards to the loaded sound" )  {
+
+        MockSoundFixture  fixture;
+        SoundManager      manager;
+
+        manager.Load( 5, "a.wav" );
+        REQUIRE( fixture.pLastCreated != nullptr );
+
+        CHECK( manager.SetVolume( 5, 0.25f ) == true );
+        CHECK( fixture.pLastCreated -> nSetVolumeCalls == 1 );
+        CHECK( fixture.pLastCreated -> fLastVolume == doctest :: Approx( 0.25f ) );
+    }
+
     TEST_CASE( "Operations on an unknown sound id return false without creating any sound" )  {
 
         MockSoundFixture  fixture;
@@ -90,6 +103,7 @@ TEST_SUITE( "sound/SoundManager" )  {
         CHECK( manager.Resume( 999 ) == false );
         CHECK( manager.IsPlaying( 999 ) == false );
         CHECK( manager.Unload( 999 ) == false );
+        CHECK( manager.SetVolume( 999, 0.5f ) == false );
 
         CHECK( fixture.pLastCreated == nullptr );
     }


### PR DESCRIPTION
## Summary
- `TileMapRenderer::SetScreenFade(float fAlpha)` — a whole-screen black overlay (`0.0` = invisible, `1.0` = fully black), drawn last each frame on top of everything else. Also exposed through `ITileMap`.
- `SoundManager::SetVolume(int nSoundId, float fVolume)` — per-sound playback volume, independent of every other loaded sound, following the existing `Play`/`Pause`/`Resume`/`Stop` id-lookup pattern. Added through `ISound`/`RayLibSound` (wraps raylib's `SetSoundVolume`) and `MockSound`.
- Together, these are the building blocks for a fade-out scene/stage transition (screen fade + audio fade together), pairing naturally with `ScriptProcessor`'s existing `LOAD_STAGE_CMD`/`PLAY_SONG_CMD`/`WAIT_CMD`.
- `tests/mock_tilemap.h`'s `MockTileMap` gets a matching `SetScreenFade` no-op override (required since `ITileMap` gained a new pure virtual), and `tests/test_soundmanager.cpp` gets a new `SetVolume` test case.

## Review history
This went through two review passes before landing here:
1. First draft placed the fade draw *outside* `TileMapRenderer`'s `GetVisible()` check (so it'd draw over stale frame-buffer content on a frame where nothing was rendered) and didn't update `MockTileMap` for the new `ITileMap::SetScreenFade` pure virtual - confirmed the latter as a real compile break by applying the diff and building (`tests/test_collisionmanager.cpp` failed with 9 "abstract class" errors).
2. Corrected version (this PR) moves the fade draw inside the `GetVisible()` branch with a comment explaining why, adds the missing `MockTileMap` override, and adds the `SoundManager::SetVolume` test case. Re-verified the same way: applied, built clean, full suite passing.

## Test plan
- [x] `cmake --build build` (library + all 5 samples + tests) - clean build
- [x] `sunlight_tests`: 69/69 cases, 2212/2212 assertions passing (1 new `SetVolume` case, 4 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)