### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
-project (sunlight VERSION 0.1.0)
+project (sunlight VERSION 0.2.0)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)


### PR DESCRIPTION
## Summary
- Bumps `project(sunlight VERSION X.Y.Z)` in `src/CMakeLists.txt` from `0.1.0` to `0.2.0`.
- Since `v0.1.0`, the only change on `main` is #65 (`TileMapRenderer::SetScreenFade()` + `SoundManager::SetVolume()`) - new backward-compatible functionality, so `MINOR` per the semver convention documented in `CONTRIBUTING.md`.
- Once this merges, I'll cut and push the `v0.2.0` tag to trigger the release workflow.

## Test plan
- [x] `cmake --build build --target sunlight` - clean build after the bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)