### PR TITLE
Route TileMapRenderer's screen fade through IEngine, not raylib directly

### DIFF
--- a/src/engines/iengine.h
+++ b/src/engines/iengine.h
@@ -108,6 +108,26 @@ namespace SunLight  {
                                            SunLight :: Base :: stColor tint ) = 0;
 
             /**
+             * @brief Must be implemented to fill a rectangle with a solid/
+             * alpha-blended color on chosen target engine. Draws exactly
+             * the rectangle it's given, with no viewport/camera awareness
+             * of its own - same as every other draw method on this
+             * interface, any clipping against a viewport must already be
+             * done by the caller before the coordinates reach here.
+             *
+             * @param nPosX X coordinate of the rectangle's top-left corner;
+             * @param nPosY Y coordinate of the rectangle's top-left corner;
+             * @param nWidth Rectangle width;
+             * @param nHeight Rectangle height;
+             * @param color Fill color (including alpha);
+             */
+            virtual void DrawFilledRectangle( int nPosX,
+                                              int nPosY,
+                                              int nWidth,
+                                              int nHeight,
+                                              SunLight :: Base :: stColor color ) = 0;
+
+            /**
              * @brief Must be implemented to return the directory the running
              * executable lives in (trailing separator included), so callers
              * can resolve resource paths relative to the binary instead of

--- a/src/engines/raylib/raylibengine.cpp
+++ b/src/engines/raylib/raylibengine.cpp
@@ -222,6 +222,26 @@ namespace SunLight  {
             }
 
             /**
+             * @brief Fill a rectangle with a solid/alpha-blended color, at
+             * exactly the coordinates given - no viewport/camera logic of
+             * its own, same as every other draw method here.
+             * @param nPosX X coordinate of the rectangle's top-left corner;
+             * @param nPosY Y coordinate of the rectangle's top-left corner;
+             * @param nWidth Rectangle width;
+             * @param nHeight Rectangle height;
+             * @param color Fill color (including alpha);
+             */
+            void RaylibEngine :: DrawFilledRectangle( int nPosX,
+                                                      int nPosY,
+                                                      int nWidth,
+                                                      int nHeight,
+                                                      SunLight :: Base :: stColor color )  {
+
+                ::DrawRectangle( nPosX, nPosY, nWidth, nHeight,
+                                Color{ color.nRed, color.nGreen, color.nBlue, color.nAlpha } );
+            }
+
+            /**
              * Draw  pixel according the specified position.
              * @param nPosX The X coordinate to plot pixel;
              * @param nPosY The Y coordinate to plot pixel;

--- a/src/engines/raylib/raylibengine.h
+++ b/src/engines/raylib/raylibengine.h
@@ -56,6 +56,12 @@ namespace SunLight  {
                                        float scale,
                                        SunLight :: Base :: stColor tint ) override;
 
+                void DrawFilledRectangle( int nPosX,
+                                          int nPosY,
+                                          int nWidth,
+                                          int nHeight,
+                                          SunLight :: Base :: stColor color ) override;
+
                 std :: string GetApplicationDirectory( void ) override;
             };
         }

--- a/src/renderer/tilemaprenderer.cpp
+++ b/src/renderer/tilemaprenderer.cpp
@@ -1788,16 +1788,21 @@ namespace SunLight {
                          * frame, there's nothing fresh to composite over -
                          * drawing it unconditionally would paint over
                          * whatever stale content is still in the frame
-                         * buffer from the last visible frame instead. Uses
-                         * raylib's own ::DrawRectangle/::Fade directly
-                         * (this class already has its own, unrelated,
-                         * wireframe-only DrawRectangle method, hence the ::
-                         * qualification - same idiom as ::SetWindowTitle
-                         * above).
+                         * buffer from the last visible frame instead.
+                         * Routed through IEngine (not raylib's ::DrawRectangle/
+                         * ::Fade directly) - full window bounds, deliberately
+                         * bypassing any viewport/camera state.
                          */
                         if( m_fScreenFadeAlpha > 0.0f )  {
-                            :: DrawRectangle( 0, 0, ( int ) m_fWindowWidth, ( int ) m_fWindowHeight,
-                                             :: Fade( BLACK, m_fScreenFadeAlpha ) );
+                            SunLight :: Base :: stColor  fadeColor = BLACK_COLOR;
+
+                            fadeColor.nAlpha = ( unsigned char ) ( 255.0f * m_fScreenFadeAlpha );
+
+                            SunLight :: Engines :: EngineFactory :: GetEngine().DrawFilledRectangle(
+                                                                  0, 0,
+                                                                  ( int ) m_fWindowWidth,
+                                                                  ( int ) m_fWindowHeight,
+                                                                  fadeColor );
                         }
                     }
 

--- a/tests/mock_engine.h
+++ b/tests/mock_engine.h
@@ -44,6 +44,7 @@ class MockEngine : public SunLight :: Engines :: IEngine  {
     int                                 nSetPixelCalls             = 0;
     int                                 nDrawTextureCalls          = 0;
     int                                 nDrawTextureTiledCalls     = 0;
+    int                                 nDrawFilledRectangleCalls  = 0;
     int                                 nGetApplicationDirectoryCalls = 0;
 
     std :: string                       strLastLoadTextureFileName;
@@ -52,6 +53,11 @@ class MockEngine : public SunLight :: Engines :: IEngine  {
     SunLight :: Base :: stRectangle     lastDrawTextureTiledSource { 0, 0, 0, 0 };
     SunLight :: Base :: stRectangle     lastDrawTextureTiledDest   { 0, 0, 0, 0 };
     float                               fLastDrawTextureTiledScale = 0.0f;
+    int                                 nLastFilledRectangleX      = 0;
+    int                                 nLastFilledRectangleY      = 0;
+    int                                 nLastFilledRectangleWidth  = 0;
+    int                                 nLastFilledRectangleHeight = 0;
+    SunLight :: Base :: stColor         lastFilledRectangleColor   { 0, 0, 0, 0 };
 
     SunLight :: Base :: TextureHandle LoadTexture( const char *szFileName, int& nWidth, int& nHeight )  {
         nLoadTextureCalls++;
@@ -87,6 +93,15 @@ class MockEngine : public SunLight :: Engines :: IEngine  {
         lastDrawTextureTiledSource = source;
         lastDrawTextureTiledDest   = dest;
         fLastDrawTextureTiledScale = scale;
+    }
+
+    void DrawFilledRectangle( int nPosX, int nPosY, int nWidth, int nHeight, SunLight :: Base :: stColor color )  {
+        nDrawFilledRectangleCalls++;
+        nLastFilledRectangleX      = nPosX;
+        nLastFilledRectangleY      = nPosY;
+        nLastFilledRectangleWidth  = nWidth;
+        nLastFilledRectangleHeight = nHeight;
+        lastFilledRectangleColor   = color;
     }
 
     std :: string GetApplicationDirectory( void )  {


### PR DESCRIPTION
## Summary
- `TileMapRenderer::Run()`'s screen fade overlay (added in #65) called raylib's `::DrawRectangle`/`::Fade` directly, bypassing the `IEngine`/`EngineFactory` seam every other draw call in this codebase already goes through.
- Adds `IEngine::DrawFilledRectangle(x, y, width, height, color)`, implemented in `RaylibEngine` via `::DrawRectangle`. Named consistently with `DrawTexture`/`DrawTextureTiled`/`SetPixel` - none of those apply viewport/camera logic internally either (that's entirely the caller's job, e.g. `TextureCanvas::Update()` computing `Viewport::GetClippedRect()` before calling `DrawTextureTiled()`), so there's no real implementation distinction between this and the existing methods to signal via a different naming scheme - just a doc comment noting it draws exactly what it's given.
- The alpha-blend math itself (previously raylib's `::Fade(BLACK, alpha)`) moves into `TileMapRenderer` as plain arithmetic against the existing `BLACK_COLOR` macro - it's just scaling one color channel, no need for `IEngine` to know about "fading" as a concept.
- `tests/mock_engine.h`'s `MockEngine` gets a matching `DrawFilledRectangle` override (call count + last args tracked), since `IEngine` gained a new pure virtual - same class of fix as `MockTileMap`/`SetScreenFade` in #65.

## Test plan
- [x] `cmake --build build` (library + all 5 samples + tests) - clean build
- [x] `sunlight_tests`: 69/69 cases, 2212/2212 assertions passing (no regressions)
- [x] Launched `collision_test` as a runtime smoke test since `tilemaprenderer.cpp` changed - clean asset load, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)