### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
-project (sunlight VERSION 0.2.0)
+project (sunlight VERSION 0.2.1)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)


### PR DESCRIPTION
## Summary
- Bumps `project(sunlight VERSION X.Y.Z)` in `src/CMakeLists.txt` from `0.2.0` to `0.2.1`.
- Since `v0.2.0`, the only change on `main` is #67 (routing `TileMapRenderer`'s screen fade through `IEngine`/`EngineFactory` instead of calling raylib directly) - an internal fix with no change to `SetScreenFade`'s public behavior/signature, so `PATCH` per the semver convention in `CONTRIBUTING.md`.
- Once this merges, I'll cut and push the `v0.2.1` tag to trigger the release workflow.

## Test plan
- [x] `cmake --build build --target sunlight` - clean build after the bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)