### PR TITLE
Fix spurious Timer callback after Stop() and make m_bRunning atomic

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
-project (sunlight VERSION 0.2.1)
+project (sunlight VERSION 0.2.2)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/src/concurrent/timer.cpp
+++ b/src/concurrent/timer.cpp
@@ -59,7 +59,20 @@ namespace SunLight {
                 m_Thread   = std :: thread( [this, nInterval, handler] {
                     while( m_bRunning ) {
                         std :: this_thread :: sleep_for( nInterval );
-                        handler( m_nTimerId );
+
+                        /*
+                         * Stop() can flip m_bRunning to false while this
+                         * thread is asleep - re-check it here, right
+                         * before actually invoking the handler, or a
+                         * guaranteed extra callback fires after every
+                         * Stop() call, racing against whatever teardown
+                         * the caller just did once Stop()'s own join()
+                         * returns (found via a caller that nils out state
+                         * its callback depends on right after stopping the
+                         * timer).
+                         */
+                        if( m_bRunning )
+                            handler( m_nTimerId );
                     }
                 } );
 

--- a/src/concurrent/timer.h
+++ b/src/concurrent/timer.h
@@ -25,6 +25,7 @@
 #include <chrono>
 #include <functional>
 #include <cstdio>
+#include <atomic>
 #include "base/object.h"
 
 
@@ -38,10 +39,10 @@ namespace SunLight {
         class Timer : public SunLight :: Base :: Object {
 
             private:
-            
-            std :: thread       m_Thread;
-            bool                m_bRunning;
-            int                 m_nTimerId;
+
+            std :: thread        m_Thread;
+            std :: atomic<bool>  m_bRunning;
+            int                  m_nTimerId;
 
 
             public:


### PR DESCRIPTION
## Summary
- `Timer`'s worker thread called `handler()` unconditionally after waking from `sleep_for()`, even if `Stop()` had already flipped `m_bRunning` to false during the sleep. This guaranteed one extra callback invocation synchronously inside `Stop()`'s `m_Thread.join()`, racing against any teardown the caller does right after calling `Stop()` (found via a caller that nulls out state its callback depends on right after stopping the timer). Fixed by re-checking `m_bRunning` immediately before invoking the handler.
- `m_bRunning` was a plain `bool` shared between the caller's thread and the worker thread with no synchronization - a data race under the C++ memory model. Changed to `std::atomic<bool>`; no other code changes needed since the existing boolean-context reads/writes (`= true`, `= false`, `while(m_bRunning)`, `if(m_bRunning)`) all work unchanged.
- Bumps version to 0.2.2 for this PATCH-level internal fix (no public API change).

## Test plan
- [x] `cmake --build build --target sunlight_tests` builds clean
- [x] `./build/tests/sunlight_tests` - 69/69 test cases, 2212/2212 assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)