### PR TITLE
Add fullscreen and window-resize support via a letterboxed render target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
-project (sunlight VERSION 0.2.2)
+project (sunlight VERSION 0.3.0)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/src/engines/iengine.h
+++ b/src/engines/iengine.h
@@ -139,6 +139,126 @@ namespace SunLight  {
              * if it could not be determined;
              */
             virtual std :: string GetApplicationDirectory( void ) = 0;
+
+            /**
+             * @brief Must be implemented to enter or leave fullscreen on
+             * chosen target engine. Implementations are free to pick
+             * whichever fullscreen strategy suits their backend best (e.g.
+             * borderless-windowed at the current monitor's native
+             * resolution); callers should only rely on @see GetFullscreen
+             * reflecting the resulting state.
+             *
+             * @param bFullscreen true to enter fullscreen, false to return
+             * to windowed mode;
+             */
+            virtual void SetFullscreen( bool bFullscreen ) = 0;
+
+            /**
+             * @brief Must be implemented to report whether the window is
+             * currently fullscreen (see @see SetFullscreen).
+             *
+             * @return true if the window is fullscreen, false if windowed;
+             */
+            virtual bool GetFullscreen( void ) = 0;
+
+            /**
+             * @brief Must be implemented to return the current width, in
+             * pixels, of the actual window/screen on chosen target engine -
+             * as opposed to any fixed internal rendering resolution a
+             * caller may be using, this always reflects the real, current
+             * (and possibly just resized) window size.
+             *
+             * @return Current window/screen width, in pixels;
+             */
+            virtual int GetScreenWidth( void ) = 0;
+
+            /**
+             * @brief Must be implemented to return the current height, in
+             * pixels, of the actual window/screen on chosen target engine
+             * (see @see GetScreenWidth).
+             *
+             * @return Current window/screen height, in pixels;
+             */
+            virtual int GetScreenHeight( void ) = 0;
+
+            /**
+             * @brief Must be implemented to allocate an offscreen render
+             * target of the given size on chosen target engine, that
+             * @see BeginRenderTarget/@see EndRenderTarget can later draw
+             * into, and @see GetRenderTargetTexture can draw out of like
+             * any other loaded texture.
+             *
+             * @param nWidth Render target width, in pixels;
+             * @param nHeight Render target height, in pixels;
+             * @return Opaque handle to the render target, to be released
+             * with @see UnloadRenderTarget once no longer needed;
+             */
+            virtual SunLight :: Base :: TextureHandle LoadRenderTarget( int nWidth, int nHeight ) = 0;
+
+            /**
+             * @brief Must be implemented to release a render target
+             * previously allocated by @see LoadRenderTarget.
+             *
+             * @param hRenderTarget The render target handle to release;
+             */
+            virtual void UnloadRenderTarget( SunLight :: Base :: TextureHandle hRenderTarget ) = 0;
+
+            /**
+             * @brief Must be implemented to redirect all subsequent drawing
+             * on chosen target engine into the given render target, until
+             * the matching @see EndRenderTarget call.
+             *
+             * @param hRenderTarget The render target to draw into;
+             */
+            virtual void BeginRenderTarget( SunLight :: Base :: TextureHandle hRenderTarget ) = 0;
+
+            /**
+             * @brief Must be implemented to stop redirecting drawing into
+             * whichever render target the matching @see BeginRenderTarget
+             * call started, resuming normal drawing.
+             */
+            virtual void EndRenderTarget( void ) = 0;
+
+            /**
+             * @brief Must be implemented to return a texture handle for the
+             * given render target's own contents, usable with
+             * @see DrawTexture/@see DrawTextureTiled/@see DrawTextureScaled
+             * exactly like any texture returned by @see LoadTexture - so a
+             * render target can be drawn out of using the same draw calls
+             * as everything else, once done being drawn into.
+             *
+             * @param hRenderTarget The render target handle whose texture
+             * is being requested;
+             * @return Texture handle for the render target's contents; not
+             * separately owned, and not valid to use with
+             * @see UnloadTexture (release it via @see UnloadRenderTarget
+             * instead, once the render target itself is no longer needed);
+             */
+            virtual SunLight :: Base :: TextureHandle GetRenderTargetTexture( SunLight :: Base :: TextureHandle hRenderTarget ) = 0;
+
+            /**
+             * @brief Must be implemented to draw a texture stretched from
+             * a source rectangle into a destination rectangle on chosen
+             * target engine, with no tiling and no viewport/camera
+             * awareness of its own - same as every other draw method on
+             * this interface, any clipping/letterboxing/scaling math must
+             * already be done by the caller before the coordinates reach
+             * here. Unlike @see DrawTextureTiled, a negative source width/
+             * height is valid here and flips the drawn result along that
+             * axis - useful for render targets, whose contents are
+             * typically stored bottom-up.
+             *
+             * @param hTexture The texture handle to draw;
+             * @param source Source rectangle defining the texture area to
+             * be drawn;
+             * @param dest Destination rectangle the source is stretched
+             * into;
+             * @param tint Color tint applied to texture;
+             */
+            virtual void DrawTextureScaled( SunLight :: Base :: TextureHandle hTexture,
+                                            SunLight :: Base :: stRectangle source,
+                                            SunLight :: Base :: stRectangle dest,
+                                            SunLight :: Base :: stColor tint ) = 0;
         };
     }
 }

--- a/src/engines/raylib/raylibengine.cpp
+++ b/src/engines/raylib/raylibengine.cpp
@@ -323,6 +323,134 @@ namespace SunLight  {
 
                 return ( szDirectory ? std :: string( szDirectory ) : std :: string() );
             }
+
+            /**
+             * @brief Enter or leave fullscreen. Uses raylib's borderless-
+             * windowed mode (not the older exclusive ToggleFullscreen(),
+             * which changes the monitor's own video mode and is markedly
+             * less reliable across platforms/window managers) - the window
+             * simply resizes to the current monitor's native resolution.
+             * @param bFullscreen true to enter fullscreen, false for windowed;
+             */
+            void RaylibEngine :: SetFullscreen( bool bFullscreen )  {
+
+                if( bFullscreen != ::IsWindowState( FLAG_BORDERLESS_WINDOWED_MODE ) )
+                    ::ToggleBorderlessWindowed();
+            }
+
+            /**
+             * @brief Query whether the window is currently fullscreen (see
+             * @see SetFullscreen).
+             */
+            bool RaylibEngine :: GetFullscreen( void )  {
+
+                return ::IsWindowState( FLAG_BORDERLESS_WINDOWED_MODE );
+            }
+
+            /**
+             * @brief Current window/screen width, in pixels.
+             */
+            int RaylibEngine :: GetScreenWidth( void )  {
+
+                return ::GetScreenWidth();
+            }
+
+            /**
+             * @brief Current window/screen height, in pixels.
+             */
+            int RaylibEngine :: GetScreenHeight( void )  {
+
+                return ::GetScreenHeight();
+            }
+
+            /**
+             * @brief Allocate an offscreen render target. Point filtering
+             * is applied so pixel-art content stays crisp when later drawn
+             * scaled up rather than blurring.
+             * @param nWidth Render target width, in pixels;
+             * @param nHeight Render target height, in pixels;
+             * @return Opaque handle to the render target;
+             */
+            SunLight :: Base :: TextureHandle RaylibEngine :: LoadRenderTarget( int nWidth, int nHeight )  {
+
+                RenderTexture2D *pRenderTarget = new RenderTexture2D;
+
+                *pRenderTarget = ::LoadRenderTexture( nWidth, nHeight );
+
+                ::SetTextureFilter( pRenderTarget -> texture, TEXTURE_FILTER_POINT );
+
+                return pRenderTarget;
+            }
+
+            /**
+             * @brief Release a render target previously allocated by
+             * @see LoadRenderTarget.
+             * @param hRenderTarget The render target handle to release;
+             */
+            void RaylibEngine :: UnloadRenderTarget( SunLight :: Base :: TextureHandle hRenderTarget )  {
+
+                RenderTexture2D *pRenderTarget = reinterpret_cast<RenderTexture2D*>( hRenderTarget );
+
+                ::UnloadRenderTexture( *pRenderTarget );
+                delete pRenderTarget;
+            }
+
+            /**
+             * @brief Redirect subsequent drawing into the given render
+             * target, until the matching @see EndRenderTarget call.
+             * @param hRenderTarget The render target to draw into;
+             */
+            void RaylibEngine :: BeginRenderTarget( SunLight :: Base :: TextureHandle hRenderTarget )  {
+
+                ::BeginTextureMode( *reinterpret_cast<RenderTexture2D*>( hRenderTarget ) );
+            }
+
+            /**
+             * @brief Stop redirecting drawing into whichever render target
+             * the matching @see BeginRenderTarget call started.
+             */
+            void RaylibEngine :: EndRenderTarget( void )  {
+
+                ::EndTextureMode();
+            }
+
+            /**
+             * @brief Return a texture handle for the given render target's
+             * own contents - points directly at the texture field embedded
+             * in the render target itself, which stays valid for as long
+             * as the render target does.
+             * @param hRenderTarget The render target handle whose texture
+             * is being requested;
+             */
+            SunLight :: Base :: TextureHandle RaylibEngine :: GetRenderTargetTexture( SunLight :: Base :: TextureHandle hRenderTarget )  {
+
+                return &( reinterpret_cast<RenderTexture2D*>( hRenderTarget ) -> texture );
+            }
+
+            /**
+             * @brief Draw a texture stretched from a source rectangle into
+             * a destination rectangle, with no tiling. A negative source
+             * width/height flips the drawn result along that axis - used
+             * for render targets, whose contents are stored bottom-up.
+             * @param hTexture The texture handle to draw;
+             * @param source Source rectangle defining the texture area to
+             * be drawn;
+             * @param dest Destination rectangle the source is stretched
+             * into;
+             * @param tint Color tint applied to texture;
+             */
+            void RaylibEngine :: DrawTextureScaled( SunLight :: Base :: TextureHandle hTexture,
+                                                    SunLight :: Base :: stRectangle source,
+                                                    SunLight :: Base :: stRectangle dest,
+                                                    SunLight :: Base :: stColor tint )  {
+
+                Texture2D  texture = *reinterpret_cast<Texture2D*>( hTexture );
+                Rectangle  sourceRect { source.x, source.y, source.width, source.height };
+                Rectangle  destRect   { dest.x, dest.y, dest.width, dest.height };
+
+                ::DrawTexturePro( texture, sourceRect, destRect, Vector2 { 0.0f, 0.0f }, 0.0f,
+                                 Color{ tint.nRed, tint.nGreen, tint.nBlue, tint.nAlpha } );
+            }
         }
     }
 }

--- a/src/engines/raylib/raylibengine.h
+++ b/src/engines/raylib/raylibengine.h
@@ -63,6 +63,23 @@ namespace SunLight  {
                                           SunLight :: Base :: stColor color ) override;
 
                 std :: string GetApplicationDirectory( void ) override;
+
+                void SetFullscreen( bool bFullscreen ) override;
+                bool GetFullscreen( void ) override;
+
+                int GetScreenWidth( void ) override;
+                int GetScreenHeight( void ) override;
+
+                SunLight :: Base :: TextureHandle LoadRenderTarget( int nWidth, int nHeight ) override;
+                void UnloadRenderTarget( SunLight :: Base :: TextureHandle hRenderTarget ) override;
+                void BeginRenderTarget( SunLight :: Base :: TextureHandle hRenderTarget ) override;
+                void EndRenderTarget( void ) override;
+                SunLight :: Base :: TextureHandle GetRenderTargetTexture( SunLight :: Base :: TextureHandle hRenderTarget ) override;
+
+                void DrawTextureScaled( SunLight :: Base :: TextureHandle hTexture,
+                                        SunLight :: Base :: stRectangle source,
+                                        SunLight :: Base :: stRectangle dest,
+                                        SunLight :: Base :: stColor tint ) override;
             };
         }
     }

--- a/src/renderer/tilemaprenderer.cpp
+++ b/src/renderer/tilemaprenderer.cpp
@@ -1075,6 +1075,7 @@ namespace SunLight {
             m_strTitle                    = szTitle;
             m_fScreenFadeAlpha            = 0.0f;
             m_pTmxMap                     = NULL;
+            m_pRenderTexture              = nullptr;
             m_bIsStarted                  = false;
             m_bWindowResizeable           = __DEFAULT_RESIZEABLE_STATUS;
             m_bClearBackground            = __DEFAULT_CLEAR_BACKGROUND;
@@ -1197,6 +1198,26 @@ namespace SunLight {
         void TileMapRenderer :: SetDrawFPS( bool bDrawFPS )  {
 
             m_bDrawFPS = bDrawFPS;
+        }
+
+        /**
+         * Enter or leave fullscreen (see @see ITileMap::SetFullscreen).
+         * Routed through IEngine rather than raylib directly, same as
+         * every other window/render primitive TileMapRenderer uses.
+         * @param bFullscreen true to enter fullscreen, false for windowed;
+         */
+        void TileMapRenderer :: SetFullscreen( bool bFullscreen )  {
+
+            SunLight :: Engines :: EngineFactory :: GetEngine().SetFullscreen( bFullscreen );
+        }
+
+        /**
+         * Query whether the window is currently fullscreen (see
+         * @see SetFullscreen).
+         */
+        bool TileMapRenderer :: GetFullscreen( void )  {
+
+            return SunLight :: Engines :: EngineFactory :: GetEngine().GetFullscreen();
         }
 
         /**
@@ -1744,6 +1765,24 @@ namespace SunLight {
 
             SetExitKey( __DEFAULT_EXIT_KEY );
             SetTargetFPS( m_nTargetFps != -1 ? m_nTargetFps : __DEFAULT_FPS );
+
+            /*
+             * Everything renders into this fixed-size offscreen target
+             * (Run() blits it scaled+letterboxed to the real window/screen
+             * every frame) - game/camera/collision math never needs to
+             * know the actual window size at all. If Start() is somehow
+             * called again without an intervening Stop(), release
+             * whatever render target already exists first so it isn't
+             * leaked.
+             */
+            if( m_pRenderTexture != nullptr )  {
+                SunLight :: Engines :: EngineFactory :: GetEngine().UnloadRenderTarget( m_pRenderTexture );
+                m_pRenderTexture = nullptr;
+            }
+
+            m_pRenderTexture = SunLight :: Engines :: EngineFactory :: GetEngine().LoadRenderTarget(
+                                                      ( int ) m_fWindowWidth,
+                                                      ( int ) m_fWindowHeight );
             m_bIsStarted = true;
 
             return m_bIsStarted;
@@ -1760,6 +1799,12 @@ namespace SunLight {
 
             if( m_bIsStarted )  {
                 UnloadMap();
+
+                if( m_pRenderTexture != nullptr )  {
+                    SunLight :: Engines :: EngineFactory :: GetEngine().UnloadRenderTarget( m_pRenderTexture );
+                    m_pRenderTexture = nullptr;
+                }
+
                 CloseWindow();
                 m_bIsStarted = false;
             }
@@ -1772,7 +1817,7 @@ namespace SunLight {
 
             if( m_bIsStarted )  {
                 while ( !WindowShouldClose() ) {
-                    BeginDrawing();
+                    SunLight :: Engines :: EngineFactory :: GetEngine().BeginRenderTarget( m_pRenderTexture );
                     if( GetVisible() )  {
                         RenderMap();
                         HandleUserInput();
@@ -1805,7 +1850,39 @@ namespace SunLight {
                                                                   fadeColor );
                         }
                     }
+                    SunLight :: Engines :: EngineFactory :: GetEngine().EndRenderTarget();
 
+                    /*
+                     * Blit the fixed-resolution render texture to the real
+                     * window, scaled to fit and letterboxed (black bars) to
+                     * preserve aspect ratio - recomputed from the actual
+                     * current screen size every single frame, so both
+                     * fullscreen (SetFullscreen) and live window resizing
+                     * (if m_bWindowResizeable) fall out of this one path
+                     * with no separate resize-event handling needed.
+                     * Source height is negative because render targets are
+                     * stored bottom-up (OpenGL convention) - this flips it
+                     * back right-side up. BeginDrawing/EndDrawing/
+                     * ClearBackground/WindowShouldClose stay raylib-direct,
+                     * same as the rest of this window's lifecycle.
+                     */
+                    int    nScreenWidth  = SunLight :: Engines :: EngineFactory :: GetEngine().GetScreenWidth();
+                    int    nScreenHeight = SunLight :: Engines :: EngineFactory :: GetEngine().GetScreenHeight();
+                    float  fScaleX       = ( float ) nScreenWidth / m_fWindowWidth;
+                    float  fScaleY       = ( float ) nScreenHeight / m_fWindowHeight;
+                    float  fScale        = ( fScaleX < fScaleY ) ? fScaleX : fScaleY;
+
+                    SunLight :: Base :: stRectangle  source { 0.0f, 0.0f, m_fWindowWidth, -m_fWindowHeight };
+                    SunLight :: Base :: stRectangle  dest   { ( nScreenWidth - ( m_fWindowWidth * fScale ) ) * 0.5f,
+                                                              ( nScreenHeight - ( m_fWindowHeight * fScale ) ) * 0.5f,
+                                                              m_fWindowWidth * fScale,
+                                                              m_fWindowHeight * fScale };
+
+                    BeginDrawing();
+                    ClearBackground( BLACK );
+                    SunLight :: Engines :: EngineFactory :: GetEngine().DrawTextureScaled(
+                                          SunLight :: Engines :: EngineFactory :: GetEngine().GetRenderTargetTexture( m_pRenderTexture ),
+                                          source, dest, WHITE_COLOR );
                     EndDrawing();
                 }
 

--- a/src/renderer/tilemaprenderer.h
+++ b/src/renderer/tilemaprenderer.h
@@ -109,6 +109,14 @@ namespace SunLight {
             bool                                       m_bDrawFPS;
             static bool                                m_bInitialized;
 
+            // Everything is rendered into this fixed-internal-resolution
+            // offscreen render target (via IEngine), then Run() blits it
+            // scaled+letterboxed to whatever the actual window/screen size
+            // currently is - the one place both fullscreen and live
+            // window-resizing are handled, since both just mean "the real
+            // screen size differs from this".
+            SunLight :: Base :: TextureHandle          m_pRenderTexture;
+
             // TmxLib overrides
             static void* TextureLoaderCallback( const char *szFileName );
             static void TextureFreeCallback( void *pTexture );
@@ -218,6 +226,8 @@ namespace SunLight {
             void SetWindowBackgroundColor( uint32_t nWindowBkColor );
             void SetClearBackground( bool bStatus );
             void SetDrawFPS( bool bDrawFPS );
+            void SetFullscreen( bool bFullscreen );
+            bool GetFullscreen( void );
 
             // View port control
             void SetViewControlMode( SunLight :: Renderer :: ViewControlMode mode );

--- a/src/tilemap/itilemap.h
+++ b/src/tilemap/itilemap.h
@@ -147,6 +147,25 @@ namespace SunLight {
             virtual void SetScreenFade( float fAlpha ) = 0;
 
             /**
+             * @brief Enter or leave fullscreen (borderless-windowed at the
+             * current monitor's native resolution). The game itself always
+             * renders at its own fixed internal resolution regardless of
+             * this setting - the renderer is responsible for scaling that
+             * up/down and letterboxing to whatever the actual window size
+             * ends up being.
+             *
+             * @param bFullscreen true to enter fullscreen, false to return
+             * to windowed mode;
+             */
+            virtual void SetFullscreen( bool bFullscreen ) = 0;
+
+            /**
+             * @brief Query whether the window is currently fullscreen (see
+             * @link SetFullscreen).
+             */
+            virtual bool GetFullscreen( void ) = 0;
+
+            /**
              * Set layer parameters.
              * @param nLayerId The layer id to set layer parameters;
              * @param layer reference to layer parameters structure to set;

--- a/tests/mock_engine.h
+++ b/tests/mock_engine.h
@@ -46,6 +46,12 @@ class MockEngine : public SunLight :: Engines :: IEngine  {
     int                                 nDrawTextureTiledCalls     = 0;
     int                                 nDrawFilledRectangleCalls  = 0;
     int                                 nGetApplicationDirectoryCalls = 0;
+    int                                 nSetFullscreenCalls        = 0;
+    int                                 nLoadRenderTargetCalls     = 0;
+    int                                 nUnloadRenderTargetCalls   = 0;
+    int                                 nBeginRenderTargetCalls    = 0;
+    int                                 nEndRenderTargetCalls      = 0;
+    int                                 nDrawTextureScaledCalls    = 0;
 
     std :: string                       strLastLoadTextureFileName;
     SunLight :: Base :: TextureHandle   hLastUnloadedTexture = nullptr;
@@ -58,6 +64,14 @@ class MockEngine : public SunLight :: Engines :: IEngine  {
     int                                 nLastFilledRectangleWidth  = 0;
     int                                 nLastFilledRectangleHeight = 0;
     SunLight :: Base :: stColor         lastFilledRectangleColor   { 0, 0, 0, 0 };
+    bool                                bFullscreen                = false;
+    int                                 nScreenWidthResult         = 0;
+    int                                 nScreenHeightResult        = 0;
+    SunLight :: Base :: TextureHandle   hLoadRenderTargetResult    = ( SunLight :: Base :: TextureHandle )  0x2;
+    SunLight :: Base :: TextureHandle   hLastUnloadedRenderTarget  = nullptr;
+    SunLight :: Base :: TextureHandle   hLastBegunRenderTarget     = nullptr;
+    SunLight :: Base :: stRectangle     lastDrawTextureScaledSource { 0, 0, 0, 0 };
+    SunLight :: Base :: stRectangle     lastDrawTextureScaledDest   { 0, 0, 0, 0 };
 
     SunLight :: Base :: TextureHandle LoadTexture( const char *szFileName, int& nWidth, int& nHeight )  {
         nLoadTextureCalls++;
@@ -107,6 +121,56 @@ class MockEngine : public SunLight :: Engines :: IEngine  {
     std :: string GetApplicationDirectory( void )  {
         nGetApplicationDirectoryCalls++;
         return strApplicationDirectoryResult;
+    }
+
+    void SetFullscreen( bool bValue )  {
+        nSetFullscreenCalls++;
+        bFullscreen = bValue;
+    }
+
+    bool GetFullscreen( void )  {
+        return bFullscreen;
+    }
+
+    int GetScreenWidth( void )  {
+        return nScreenWidthResult;
+    }
+
+    int GetScreenHeight( void )  {
+        return nScreenHeightResult;
+    }
+
+    SunLight :: Base :: TextureHandle LoadRenderTarget( int nWidth, int nHeight )  {
+        nLoadRenderTargetCalls++;
+        return hLoadRenderTargetResult;
+    }
+
+    void UnloadRenderTarget( SunLight :: Base :: TextureHandle hRenderTarget )  {
+        nUnloadRenderTargetCalls++;
+        hLastUnloadedRenderTarget = hRenderTarget;
+    }
+
+    void BeginRenderTarget( SunLight :: Base :: TextureHandle hRenderTarget )  {
+        nBeginRenderTargetCalls++;
+        hLastBegunRenderTarget = hRenderTarget;
+    }
+
+    void EndRenderTarget( void )  {
+        nEndRenderTargetCalls++;
+    }
+
+    SunLight :: Base :: TextureHandle GetRenderTargetTexture( SunLight :: Base :: TextureHandle hRenderTarget )  {
+        return hRenderTarget;
+    }
+
+    void DrawTextureScaled( SunLight :: Base :: TextureHandle hTexture,
+                            SunLight :: Base :: stRectangle source,
+                            SunLight :: Base :: stRectangle dest,
+                            SunLight :: Base :: stColor tint )  {
+        nDrawTextureScaledCalls++;
+        hLastDrawnTexture           = hTexture;
+        lastDrawTextureScaledSource = source;
+        lastDrawTextureScaledDest   = dest;
     }
 };
 

--- a/tests/mock_tilemap.h
+++ b/tests/mock_tilemap.h
@@ -66,6 +66,11 @@ class MockTileMap : public SunLight :: TileMap :: ITileMap  {
     void MoveCameraRight( void )  {}
     void SetWindowTitle( const std :: string& )  {}
     void SetScreenFade( float )  {}
+    void SetFullscreen( bool )  {}
+
+    bool GetFullscreen( void )  {
+        return false;
+    }
 
     bool SetLayer( int, SunLight :: TileMap :: stLayer& )  {
         return false;


### PR DESCRIPTION
## Summary
- `TileMapRenderer` now renders into a fixed-internal-resolution offscreen render target every frame, then blits it scaled and letterboxed to whatever the actual window/screen size currently is. This one path handles both fullscreen (new `ITileMap::SetFullscreen`/`GetFullscreen`) and live window resizing uniformly.
- Adds `SetFullscreen`/`GetFullscreen`, `GetScreenWidth`/`GetScreenHeight`, render-target `LoadRenderTarget`/`UnloadRenderTarget`/`BeginRenderTarget`/`EndRenderTarget`/`GetRenderTargetTexture`, and a non-tiled `DrawTextureScaled` to `IEngine`, implemented in `RaylibEngine` - keeps every new raylib call (borderless-windowed toggle, render textures, texture-mode, the scaled blit) out of `TileMapRenderer`, consistent with how `DrawFilledRectangle` was routed for the screen-fade feature (`IsWindowState`/`ToggleBorderlessWindowed`/`LoadRenderTexture`/`BeginTextureMode`/`EndTextureMode`/`GetScreenWidth`/`GetScreenHeight`/`DrawTexturePro` never appear in `tilemaprenderer.cpp`). `BeginDrawing`/`EndDrawing`/`ClearBackground`/`WindowShouldClose` stay raylib-direct, matching the already-documented window-lifecycle exception.
- `MockEngine` gains matching overrides for all the new `IEngine` methods; `MockTileMap` gains no-op `SetFullscreen`/`GetFullscreen`.
- `Start()` now releases any existing render target before allocating a new one, closing a leak that would otherwise hit if `Start()` were ever called twice without an intervening `Stop()`.
- Bumps version to 0.3.0 (new public API, MINOR per this project's pre-1.0 convention).

## Test plan
- [x] `cmake --build build --target sunlight_tests` builds clean, no warnings
- [x] `./build/tests/sunlight_tests` - 69/69 test cases, 2212/2212 assertions pass
- [x] Ran `tilemaprenderer_test` sample directly - raylib's own log confirms the render target is created at the correct size and cleanly torn down on `Stop()` (`FBO: [ID 1] Unloaded framebuffer from VRAM`), no errors across the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)