### PR TITLE
Sync generated Doxygen docs' version number with the actual release

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -27,6 +27,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y doxygen graphviz
 
+      - name: Extract project version
+        run: echo "SUNLIGHT_VERSION=$(grep -oP '(?<=VERSION )[0-9]+\.[0-9]+\.[0-9]+' src/CMakeLists.txt)" >> "$GITHUB_ENV"
+
       - name: Generate documentation
         run: doxygen Doxyfile
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "sunlight"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.1.0
+PROJECT_NUMBER         = $(SUNLIGHT_VERSION)
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewers a


### PR DESCRIPTION
## Summary
- `Doxyfile`'s `PROJECT_NUMBER` was hardcoded to `0.1.0` since the Doxygen workflow was first added (#60) and never updated since - the published docs at https://popolony2k.github.io/sunlight/ kept showing `0.1.0` through every release up to the current `0.3.0`.
- `PROJECT_NUMBER` now reads `$(SUNLIGHT_VERSION)` (Doxygen supports `$(ENV_VAR)` substitution in Doxyfile values), and `.github/workflows/doxygen.yml` greps the version straight out of `src/CMakeLists.txt` and exports it before running `doxygen` - keeps the two in sync automatically on every future version bump, no manual step to forget.

## Test plan
- [x] Ran `doxygen Doxyfile` locally with `SUNLIGHT_VERSION=0.3.0` exported - generated `doc/doxygen/html/index.html` correctly shows `sunlight 0.3.0`, no `0.1.0` left anywhere in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)