### PR TITLE
Add SetCameraPosition and GetObjectByName for scripted camera control

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
-project (sunlight VERSION 0.3.0)
+project (sunlight VERSION 0.4.0)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/src/renderer/tilemaprenderer.cpp
+++ b/src/renderer/tilemaprenderer.cpp
@@ -1392,6 +1392,37 @@ namespace SunLight {
         }
 
         /**
+         * @brief Jump the camera so the given world-space coordinate is
+         * shown at the top-left of the viewport. m_CameraPos itself is the
+         * negated world coordinate currently shown at the viewport's
+         * top-left (confirmed via every MoveCamera call and the alignment-
+         * init code above, all of which treat it that way) - callers pass plain,
+         * positive world-space coordinates (the same space stObject's
+         * x/y and TileMapToTileMatrix's input already use), not this
+         * internal negated convention.
+         *
+         * Unlike MoveCameraUp/Down/Left/Right, this does not clamp to map
+         * boundaries - same unconditional-application spirit as
+         * ResetCamera(). Move* re-validates every call because it's nudged
+         * one small step at a time, every frame; this is a deliberate jump
+         * to a caller-supplied target (e.g. an authored map marker via
+         * GetObjectByName()) that's assumed already valid - clamping it
+         * would work against exactly what it's for, landing precisely on
+         * that target instead of wherever the nearest in-bounds point is.
+         * The caller is responsible for passing a valid target.
+         *
+         * @param nX World-space x coordinate (pixels) to show at the
+         * viewport's left edge.
+         * @param nY World-space y coordinate (pixels) to show at the
+         * viewport's top edge.
+         */
+        void TileMapRenderer :: SetCameraPosition( int nX, int nY )  {
+
+            m_CameraPos.x = ( float ) -nX;
+            m_CameraPos.y = ( float ) -nY;
+        }
+
+        /**
          * @brief Set the application window's title, replacing whatever
          * title it was created with.
          *
@@ -1677,6 +1708,73 @@ namespace SunLight {
             }
 
             return false;
+        }
+
+        /**
+         * @brief Recursive helper for GetObjectByName() - walks pLayer's
+         * linked list looking for a named object inside any L_OBJGR layer,
+         * recursing into L_GROUP the same way DrawAllLayers() does, so a
+         * map that nests an object group inside a <group> layer is still
+         * searched correctly instead of silently skipped.
+         *
+         * @param pLayer Head of the tmx_layer linked list to search;
+         * @param szObjectName The object's name, as set in the map editor;
+         * @param object Reference to receive the object's data if found;
+         * @return true if an object with this name was found, false
+         * otherwise;
+         */
+        bool TileMapRenderer :: FindObjectByName( tmx_layer *pLayer, const char *szObjectName, SunLight :: TileMap :: stObject& object )  {
+
+            for( ; pLayer != nullptr; pLayer = pLayer -> next )  {
+
+                if( pLayer -> type == L_GROUP )  {
+                    if( FindObjectByName( pLayer -> content.group_head, szObjectName, object ) )
+                        return true;
+
+                    continue;
+                }
+
+                if( pLayer -> type != L_OBJGR )
+                    continue;
+
+                for( tmx_object *pObject = pLayer -> content.objgr -> head; pObject != nullptr; pObject = pObject -> next )  {
+
+                    if( ( pObject -> name != nullptr ) && ( ::strcmp( pObject -> name, szObjectName ) == 0 ) )  {
+
+                        object.strName            = pObject -> name;
+                        object.dimension.pos.x    = ( int ) pObject -> x;
+                        object.dimension.pos.y    = ( int ) pObject -> y;
+                        object.dimension.size.nWidth  = ( int ) pObject -> width;
+                        object.dimension.size.nHeight = ( int ) pObject -> height;
+
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /**
+         * @brief Look up a level-design-authored object (a Tiled <object>
+         * placed inside any <objectgroup> layer) by name - searches every
+         * object-group layer in the loaded map, including ones nested
+         * inside <group> layers (see FindObjectByName()), since libtmx has
+         * no tmx_find_object_by_name of it's own (only
+         * tmx_find_object_by_id, no use here - objects are authored/named
+         * by hand in the map editor, not looked up by their internal id).
+         *
+         * @param szObjectName The object's name, as set in the map editor.
+         * @param object Reference to receive the object's data if found.
+         * @return true if an object with this name was found, false
+         * otherwise (including if no map is loaded).
+         */
+        bool TileMapRenderer :: GetObjectByName( const char *szObjectName, SunLight :: TileMap :: stObject& object )  {
+
+            if( m_pTmxMap == nullptr )
+                return false;
+
+            return FindObjectByName( m_pTmxMap -> ly_head, szObjectName, object );
         }
 
         /**

--- a/src/renderer/tilemaprenderer.h
+++ b/src/renderer/tilemaprenderer.h
@@ -182,6 +182,9 @@ namespace SunLight {
             void DrawAllLayers( tmx_layer *pLayer );
             void RenderMap( void );
 
+            // Object management internals
+            bool FindObjectByName( tmx_layer *pLayer, const char *szObjectName, SunLight :: TileMap :: stObject& object );
+
             // General engine handlers
             void InitalizeDefaultUserInputHandlers( void );
 
@@ -253,6 +256,7 @@ namespace SunLight {
             void MoveCameraDown( void );
             void MoveCameraLeft( void );
             void MoveCameraRight( void );
+            void SetCameraPosition( int nX, int nY );
 
             // Window management
             void SetWindowTitle( const std :: string &strTitle );
@@ -277,6 +281,9 @@ namespace SunLight {
             bool LoadMap( const char *szTxMapFile, SunLight :: TileMap :: ITileMap :: MapAlignment alignment = MAP_ALIGNMENT_CENTER );
             bool UnloadMap( void );
             bool GetMapInfo( SunLight :: TileMap :: stMapInfo& mapInfo );
+
+            // Object management
+            bool GetObjectByName( const char *szObjectName, SunLight :: TileMap :: stObject& object );
 
             // Collision management
             SunLight :: Collision :: ICollisionManager& GetCollisionManager( void );

--- a/src/tilemap/itilemap.h
+++ b/src/tilemap/itilemap.h
@@ -129,6 +129,24 @@ namespace SunLight {
             virtual void MoveCameraRight( void ) = 0;
 
             /**
+             * @brief Jump the camera so the given world-space coordinate is
+             * shown at the top-left of the viewport - an absolute move,
+             * unlike MoveCameraUp/Down/Left/Right's incremental one-step
+             * moves (and unlike ResetCamera, which only returns to the
+             * map's original load-time position).
+             *
+             * Unlike MoveCameraUp/Down/Left/Right, this does not clamp to
+             * map boundaries - the caller is responsible for passing a
+             * valid target (e.g. a position read via GetObjectByName()).
+             *
+             * @param nX World-space x coordinate (pixels) to show at the
+             * viewport's left edge.
+             * @param nY World-space y coordinate (pixels) to show at the
+             * viewport's top edge.
+             */
+            virtual void SetCameraPosition( int nX, int nY ) = 0;
+
+            /**
              * @brief Set the application window's title, replacing whatever
              * title it was created with.
              *
@@ -220,6 +238,20 @@ namespace SunLight {
              * receive the map information.
              */
             virtual bool GetMapInfo( SunLight :: TileMap :: stMapInfo& mapInfo ) = 0;
+
+            /**
+             * @brief Look up a level-design-authored object (a Tiled
+             * <object> placed inside any <objectgroup> layer, eg. a
+             * trigger/marker) by name.
+             *
+             * @param szObjectName The object's name, as set in the map
+             * editor.
+             * @param object Reference to receive the object's data if
+             * found.
+             * @return true if an object with this name was found (searched
+             * across every object-group layer), false otherwise.
+             */
+            virtual bool GetObjectByName( const char *szObjectName, SunLight :: TileMap :: stObject& object ) = 0;
 
             /**
              * Return the reference to internal renderer collision manager.

--- a/src/tilemap/tilemapdefs.h
+++ b/src/tilemap/tilemapdefs.h
@@ -22,6 +22,7 @@
 #define __TILEMAPDEFS_H__
 
 #include <tmx.h>
+#include <string>
 
 
 namespace SunLight  {
@@ -87,6 +88,16 @@ namespace SunLight  {
             stSize2D       mapSize;
             stSize2D       tileSize;
             tmx_map        *pMap;
+        };
+
+        /**
+         * A single Tiled object (<object> element inside an <objectgroup>
+         * layer), eg. a level-design-authored marker/trigger placed in the
+         * map editor - world-space position/size, in pixels.
+         */
+        struct stObject  {
+            std :: string  strName;
+            stDimension2D  dimension;
         };
     }
 }

--- a/tests/mock_tilemap.h
+++ b/tests/mock_tilemap.h
@@ -64,6 +64,7 @@ class MockTileMap : public SunLight :: TileMap :: ITileMap  {
     void MoveCameraDown( void )  {}
     void MoveCameraLeft( void )  {}
     void MoveCameraRight( void )  {}
+    void SetCameraPosition( int, int )  {}
     void SetWindowTitle( const std :: string& )  {}
     void SetScreenFade( float )  {}
     void SetFullscreen( bool )  {}
@@ -110,6 +111,10 @@ class MockTileMap : public SunLight :: TileMap :: ITileMap  {
     }
 
     bool GetMapInfo( SunLight :: TileMap :: stMapInfo& )  {
+        return false;
+    }
+
+    bool GetObjectByName( const char*, SunLight :: TileMap :: stObject& )  {
         return false;
     }
 


### PR DESCRIPTION
## Summary
- `SetCameraPosition(int nX, int nY)` jumps the camera to an absolute world-space coordinate, complementing `MoveCameraUp/Down/Left/Right`'s incremental one-step moves and `ResetCamera`'s return-to-load-position. Verified the sign convention (`m_CameraPos` stores the *negated* world coordinate shown at the viewport's top-left) against the actual render math and existing alignment code. Deliberately unclamped, documented explicitly as such in both `ITileMap` and `TileMapRenderer` - same unconditional-application spirit as `ResetCamera`, since it's a jump to a caller-supplied, presumed-valid target rather than a per-frame nudge.
- `GetObjectByName(const char *szObjectName, stObject &object)` looks up a Tiled `<object>` (a level-design-authored marker/trigger placed in an `<objectgroup>` layer) by name, via a new `stObject` struct. The search recurses into `<group>` layers via a new private `FindObjectByName()` helper, mirroring `DrawAllLayers()`'s existing recursion pattern - so an object group nested inside a `<group>` layer is found instead of silently skipped, matching how libtmx's own `tmx_find_layer_by_id`/`tmx_find_layer_by_name` (which `GetLayer()` already delegates to) behave.
- Together these support scripted set-pieces like a sub-boss arena: two named map markers bound the fight's row range, `GetObjectByName` reads their positions at load time, `SetCameraPosition` snaps the camera back to the start mark each time it reaches the end, looping while the boss is alive.
- `MockTileMap` gains matching stub overrides for both.
- Bumps version to 0.4.0 (new public API, MINOR per this project's pre-1.0 convention).

## Test plan
- [x] `cmake --build build --target sunlight_tests` builds clean, no warnings
- [x] `./build/tests/sunlight_tests` - 69/69 test cases, 2212/2212 assertions pass
- [x] Verified `stDimension2D`/`stSize2D` field usage and `tmx_layer`/`tmx_object`/`tmx_object_group` field names against the vendored libtmx header

🤖 Generated with [Claude Code](https://claude.com/claude-code)