### PR TITLE
Add GetCameraPosition, the read-side counterpart to SetCameraPosition

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
-project (sunlight VERSION 0.4.0)
+project (sunlight VERSION 0.5.0)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/src/renderer/tilemaprenderer.cpp
+++ b/src/renderer/tilemaprenderer.cpp
@@ -1423,6 +1423,23 @@ namespace SunLight {
         }
 
         /**
+         * @brief Read the world-space coordinate currently shown at the
+         * top-left of the viewport - the exact inverse of
+         * SetCameraPosition (m_CameraPos itself stores the negated
+         * coordinate, same convention that method's own comment covers).
+         *
+         * @param nX Receives the world-space x coordinate (pixels)
+         * currently shown at the viewport's left edge.
+         * @param nY Receives the world-space y coordinate (pixels)
+         * currently shown at the viewport's top edge.
+         */
+        void TileMapRenderer :: GetCameraPosition( int &nX, int &nY )  {
+
+            nX = ( int ) -m_CameraPos.x;
+            nY = ( int ) -m_CameraPos.y;
+        }
+
+        /**
          * @brief Set the application window's title, replacing whatever
          * title it was created with.
          *

--- a/src/renderer/tilemaprenderer.h
+++ b/src/renderer/tilemaprenderer.h
@@ -257,6 +257,7 @@ namespace SunLight {
             void MoveCameraLeft( void );
             void MoveCameraRight( void );
             void SetCameraPosition( int nX, int nY );
+            void GetCameraPosition( int &nX, int &nY );
 
             // Window management
             void SetWindowTitle( const std :: string &strTitle );

--- a/src/tilemap/itilemap.h
+++ b/src/tilemap/itilemap.h
@@ -147,6 +147,22 @@ namespace SunLight {
             virtual void SetCameraPosition( int nX, int nY ) = 0;
 
             /**
+             * @brief Read the world-space coordinate currently shown at the
+             * top-left of the viewport - the exact inverse of
+             * SetCameraPosition, and the only reliable way to know the
+             * camera's current scroll position (there is no derived way to
+             * compute it purely from map/viewport size - alignment's own
+             * internal math isn't part of this interface's contract and
+             * isn't safe to replicate outside it).
+             *
+             * @param nX Receives the world-space x coordinate (pixels)
+             * currently shown at the viewport's left edge.
+             * @param nY Receives the world-space y coordinate (pixels)
+             * currently shown at the viewport's top edge.
+             */
+            virtual void GetCameraPosition( int &nX, int &nY ) = 0;
+
+            /**
              * @brief Set the application window's title, replacing whatever
              * title it was created with.
              *

--- a/tests/mock_tilemap.h
+++ b/tests/mock_tilemap.h
@@ -65,6 +65,11 @@ class MockTileMap : public SunLight :: TileMap :: ITileMap  {
     void MoveCameraLeft( void )  {}
     void MoveCameraRight( void )  {}
     void SetCameraPosition( int, int )  {}
+
+    void GetCameraPosition( int &nX, int &nY )  {
+        nX = 0;
+        nY = 0;
+    }
     void SetWindowTitle( const std :: string& )  {}
     void SetScreenFade( float )  {}
     void SetFullscreen( bool )  {}


### PR DESCRIPTION
## Summary
- `GetCameraPosition(int &nX, int &nY)` returns the world-space coordinate currently shown at the viewport's top-left - the exact algebraic inverse of `SetCameraPosition` (`m_CameraPos` stores the negated coordinate; this just negates it back). Previously there was no public way to read the camera's current scroll position at all.
- Verified the round-trip is exact: `SetCameraPosition(x, y)` followed by `GetCameraPosition` returns exactly `(x, y)` back, for any realistic pixel coordinate (int -> float -> int is lossless well within float's mantissa range). No raylib involved - pure struct-field arithmetic.
- `MockTileMap` gains a matching stub that zero-fills the output params, consistent with how the mock handles other output-param methods (`GetLayer`, `TileMapToTileMatrix`).
- Bumps version to 0.5.0 (new public API, MINOR per this project's pre-1.0 convention).

## Test plan
- [x] `cmake --build build --target sunlight_tests` builds clean, no warnings
- [x] `./build/tests/sunlight_tests` - 69/69 test cases, 2212/2212 assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)