### PR TITLE
Add Collider::SetInset for shrinking a collider's own hit-test rect

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
-project (sunlight VERSION 0.5.0)
+project (sunlight VERSION 0.6.0)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/src/collision/collider.cpp
+++ b/src/collision/collider.cpp
@@ -66,6 +66,10 @@ namespace SunLight {
          */
         Collider :: Collider( void )  {
 
+            m_fInsetLeft   = 0.0f;
+            m_fInsetTop    = 0.0f;
+            m_fInsetRight  = 0.0f;
+            m_fInsetBottom = 0.0f;
         }
 
         /**
@@ -76,24 +80,50 @@ namespace SunLight {
         }
 
         /**
+         * Compute the rectangle actually used for this collider's own side
+         * of an overlap test - the parent's full dimension with SetInset's
+         * percentages shaved off each edge. See SetInset's own doc comment
+         * for why this is recomputed here rather than cached.
+         * @param fX Receives the effective rectangle's X position;
+         * @param fY Receives the effective rectangle's Y position;
+         * @param fWidth Receives the effective rectangle's width;
+         * @param fHeight Receives the effective rectangle's height;
+         */
+        void Collider :: GetEffectiveRect( float &fX, float &fY, float &fWidth, float &fHeight )  {
+
+            SunLight :: TileMap :: stDimension2D&  self = GetDimension2D();
+            float                                 fInsetLeftPx   = self.size.nWidth  * m_fInsetLeft;
+            float                                 fInsetTopPx    = self.size.nHeight * m_fInsetTop;
+            float                                 fInsetRightPx  = self.size.nWidth  * m_fInsetRight;
+            float                                 fInsetBottomPx = self.size.nHeight * m_fInsetBottom;
+
+            fX      = self.pos.x + fInsetLeftPx;
+            fY      = self.pos.y + fInsetTopPx;
+            fWidth  = self.size.nWidth  - fInsetLeftPx - fInsetRightPx;
+            fHeight = self.size.nHeight - fInsetTopPx  - fInsetBottomPx;
+        }
+
+        /**
          * Check if collider object area has been hit by tile passed as parameter.
          * @param tile Reference to the tile struct containing all tile information;
          */
         bool Collider :: Hit( SunLight :: TileMap :: stTile &tile )  {
 
             SunLight :: TileMap :: stDimension2D&  viewport    = GetViewport().GetDimension2D();
-            SunLight :: TileMap :: stDimension2D&  dimension   = GetDimension2D();
             tmx_object                           *pCollision = tile.pTile -> collision;
             bool                                 bHit        = false;
+            float                                fSelfX, fSelfY, fSelfWidth, fSelfHeight;
+
+            GetEffectiveRect( fSelfX, fSelfY, fSelfWidth, fSelfHeight );
 
             while( pCollision )  {
 
                 switch( pCollision -> obj_type )  {
                     case OT_SQUARE :
-                        bHit = RectRect( ( float ) ( dimension.pos.x + viewport.pos.x ),
-                                         ( float ) ( dimension.pos.y + viewport.pos.y ),
-                                         ( float ) dimension.size.nWidth,
-                                         ( float ) dimension.size.nHeight,
+                        bHit = RectRect( fSelfX + ( float ) viewport.pos.x,
+                                         fSelfY + ( float ) viewport.pos.y,
+                                         fSelfWidth,
+                                         fSelfHeight,
                                          ( float ) ( tile.dimension.pos.x + pCollision -> x ),
                                          ( float ) ( tile.dimension.pos.y + pCollision -> y ),
                                          ( float ) pCollision -> width,
@@ -138,16 +168,36 @@ namespace SunLight {
          */
         bool Collider :: Hit( SunLight :: TileMap :: stDimension2D &dimension )  {
 
-            SunLight :: TileMap :: stDimension2D&  self = GetDimension2D();
+            float  fSelfX, fSelfY, fSelfWidth, fSelfHeight;
 
-            return RectRect( ( float ) self.pos.x,
-                             ( float ) self.pos.y,
-                             ( float ) self.size.nWidth,
-                             ( float ) self.size.nHeight,
+            GetEffectiveRect( fSelfX, fSelfY, fSelfWidth, fSelfHeight );
+
+            return RectRect( fSelfX,
+                             fSelfY,
+                             fSelfWidth,
+                             fSelfHeight,
                              ( float ) dimension.pos.x,
                              ( float ) dimension.pos.y,
                              ( float ) dimension.size.nWidth,
                              ( float ) dimension.size.nHeight );
+        }
+
+        /**
+         * Set the inset (as fractions of the parent's own width/height)
+         * shrinking the rectangle this collider's Hit() checks use for it's
+         * own side of the test. See the header's own doc comment for the
+         * full explanation.
+         * @param fLeftPct Fraction of width to shrink off the left edge;
+         * @param fTopPct Fraction of height to shrink off the top edge;
+         * @param fRightPct Fraction of width to shrink off the right edge;
+         * @param fBottomPct Fraction of height to shrink off the bottom edge;
+         */
+        void Collider :: SetInset( float fLeftPct, float fTopPct, float fRightPct, float fBottomPct )  {
+
+            m_fInsetLeft   = fLeftPct;
+            m_fInsetTop    = fTopPct;
+            m_fInsetRight  = fRightPct;
+            m_fInsetBottom = fBottomPct;
         }
     }
 }

--- a/src/collision/collider.h
+++ b/src/collision/collider.h
@@ -29,9 +29,14 @@ namespace SunLight {
 
         /**
          * @brief Collider implementation.
-         * 
+         *
          */
         class Collider : public SunLight :: Canvas :: BaseCanvas {
+
+            float  m_fInsetLeft;
+            float  m_fInsetTop;
+            float  m_fInsetRight;
+            float  m_fInsetBottom;
 
             bool RectRect( float fRect1X,
                         float fRect1Y,
@@ -42,6 +47,11 @@ namespace SunLight {
                         float fRect2Width,
                         float fRect2Height );
 
+            void GetEffectiveRect( float &fX,
+                                   float &fY,
+                                   float &fWidth,
+                                   float &fHeight );
+
             public:
 
             Collider( void );
@@ -49,6 +59,35 @@ namespace SunLight {
 
             bool Hit( SunLight :: TileMap :: stTile &tile );
             bool Hit( SunLight :: TileMap :: stDimension2D &dimension );
+
+            /**
+             * @brief Shrinks the rectangle actually used for this collider's
+             * own overlap tests, relative to it's parent's full render
+             * dimension - the dimension itself (position/size, tracked via
+             * SetDimension2DPtr) is untouched, so this only affects the
+             * area Hit() considers "self", not what's drawn or how the
+             * parent's position is tracked. Every percentage is a fraction
+             * (0.0-1.0) of the parent's own width/height, recomputed from
+             * the current dimension on every Hit() call rather than cached
+             * as pixels, so it stays correct even if the parent's own size
+             * changes at runtime (e.g. a differently-sized active texture
+             * sequence). Defaults to 0 on every side (full-size collision,
+             * today's behavior) until explicitly set. Not clamped/validated -
+             * opposing percentages summing past 1.0 on an axis (e.g.
+             * fLeftPct=0.6, fRightPct=0.6) push that axis's effective size
+             * negative; RectRect() doesn't crash or false-positive on that,
+             * it just fails toward "never hits", but it's still the caller's
+             * responsibility to pass sane values (same convention as
+             * TileMapRenderer::SetCameraPosition's own unclamped position).
+             * @param fLeftPct Fraction of width to shrink off the left edge;
+             * @param fTopPct Fraction of height to shrink off the top edge;
+             * @param fRightPct Fraction of width to shrink off the right edge;
+             * @param fBottomPct Fraction of height to shrink off the bottom edge;
+             */
+            void SetInset( float fLeftPct,
+                           float fTopPct,
+                           float fRightPct,
+                           float fBottomPct );
         };
     }
 }

--- a/tests/test_collider.cpp
+++ b/tests/test_collider.cpp
@@ -58,4 +58,48 @@ TEST_SUITE( "collision/Collider" )  {
 
         CHECK( collider.Hit( other ) == true );
     }
+
+    TEST_CASE( "SetInset defaults to zero - unchanged full-size behavior" )  {
+
+        Collider      collider;
+        stDimension2D self  { { 0, 0 }, { 50, 50 } };
+        stDimension2D other { { 45, 0 }, { 50, 50 } };
+
+        collider.SetDimension2D( self );
+
+        // Same overlap as the plain full-size Hit() tests above - confirms
+        // an untouched Collider (no SetInset call) behaves exactly as
+        // before this feature existed.
+        CHECK( collider.Hit( other ) == true );
+    }
+
+    TEST_CASE( "SetInset shrinks the collider's own side of the test" )  {
+
+        Collider      collider;
+        // 50x50 self, 20% inset on every edge -> effective rect is
+        // (10,10)-(40,40), a 30x30 box centered in the original 50x50.
+        stDimension2D self  { { 0, 0 }, { 50, 50 } };
+        stDimension2D other { { 45, 0 }, { 50, 50 } };
+
+        collider.SetDimension2D( self );
+        collider.SetInset( 0.2f, 0.2f, 0.2f, 0.2f );
+
+        // other still overlaps self's full 50x50 box (as the test above
+        // confirms) but no longer reaches the inset-shrunk 30x30 box, which
+        // now ends at x=40 while other starts at x=45.
+        CHECK( collider.Hit( other ) == false );
+    }
+
+    TEST_CASE( "SetInset still detects overlap within the shrunk box" )  {
+
+        Collider      collider;
+        stDimension2D self  { { 0, 0 }, { 50, 50 } };
+        stDimension2D other { { 35, 0 }, { 50, 50 } };
+
+        collider.SetDimension2D( self );
+        collider.SetInset( 0.2f, 0.2f, 0.2f, 0.2f );
+
+        // Effective rect ends at x=40 - other starts at x=35, still inside it.
+        CHECK( collider.Hit( other ) == true );
+    }
 }


### PR DESCRIPTION
## Summary
- `Collider::SetInset(fLeftPct, fTopPct, fRightPct, fBottomPct)` shrinks the rectangle `Hit()` uses for a collider's own side of the overlap test, as fractions (0.0-1.0) of the parent's own width/height - useful for sprites whose rendered art has transparent padding around the actual hitbox.
- Both `Hit()` overloads route through a new private `GetEffectiveRect()`, recomputed from the live dimension on every call rather than cached as pixels, so it keeps working if the parent's size changes at runtime.
- Fully backward-compatible: insets default to 0 in the constructor, so any existing `Collider` that never calls `SetInset` behaves identically to before.
- Not clamped/validated by design, documented as such: opposing percentages summing past 1.0 on an axis push that axis's effective size negative, but `RectRect()` fails safe toward "never hits" rather than crashing or false-positiving - same convention as `TileMapRenderer::SetCameraPosition`'s intentionally-unclamped position.
- Three new doctest cases: default (unchanged) behavior, an inset shrinking a hit away, and an inset that still detects an overlap within the shrunk box - hand-verified the AABB math for all three against `RectRect`'s actual formula.
- Bumps version to 0.6.0 (new public API, MINOR per this project's pre-1.0 convention).

## Test plan
- [x] `cmake --build build --target sunlight_tests` builds clean, no warnings
- [x] `./build/tests/sunlight_tests` - 72/72 test cases, 2215/2215 assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)