### PR TITLE
Fix CollisionManager only honoring the first collider's own SetInset

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
-project (sunlight VERSION 0.6.0)
+project (sunlight VERSION 0.7.0)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/src/collision/collider.cpp
+++ b/src/collision/collider.cpp
@@ -183,6 +183,43 @@ namespace SunLight {
         }
 
         /**
+         * Check if this collider's own effective (SetInset-shrunk)
+         * rectangle overlaps another collider's own effective rectangle -
+         * unlike the stDimension2D overload above (which only ever applies
+         * THIS side's inset against the other's raw, full area - by
+         * design, for callers testing against an arbitrary rectangle that
+         * isn't itself a Collider, e.g. a tile's collision shape), this
+         * applies BOTH colliders' own SetInset shrink, so a collider-to-
+         * collider overlap test correctly honors each side's own inset
+         * independently. CollisionManager::Update() uses this one for it's
+         * collider-to-collider rule checks - using the stDimension2D
+         * overload there instead silently ignored the second collider's
+         * own inset entirely, since only the first side's GetEffectiveRect
+         * was ever consulted (found via Caravellius, 2026-08-11 - a
+         * boss's own head hitbox never responded to SetInset at all,
+         * however aggressively it was shrunk, because it was always the
+         * second collider in it's own collision_add_rule pairing).
+         * @param other The other collider to test against;
+         */
+        bool Collider :: Hit( Collider &other )  {
+
+            float  fSelfX, fSelfY, fSelfWidth, fSelfHeight;
+            float  fOtherX, fOtherY, fOtherWidth, fOtherHeight;
+
+            GetEffectiveRect( fSelfX, fSelfY, fSelfWidth, fSelfHeight );
+            other.GetEffectiveRect( fOtherX, fOtherY, fOtherWidth, fOtherHeight );
+
+            return RectRect( fSelfX,
+                             fSelfY,
+                             fSelfWidth,
+                             fSelfHeight,
+                             fOtherX,
+                             fOtherY,
+                             fOtherWidth,
+                             fOtherHeight );
+        }
+
+        /**
          * Set the inset (as fractions of the parent's own width/height)
          * shrinking the rectangle this collider's Hit() checks use for it's
          * own side of the test. See the header's own doc comment for the

--- a/src/collision/collider.h
+++ b/src/collision/collider.h
@@ -59,6 +59,7 @@ namespace SunLight {
 
             bool Hit( SunLight :: TileMap :: stTile &tile );
             bool Hit( SunLight :: TileMap :: stDimension2D &dimension );
+            bool Hit( Collider &other );
 
             /**
              * @brief Shrinks the rectangle actually used for this collider's

--- a/src/collision/collisionmanager.cpp
+++ b/src/collision/collisionmanager.cpp
@@ -244,7 +244,14 @@ namespace SunLight {
             for( auto& pPair : m_ColliderToColliderRuleList )  {
                 for( Collider *pFirst : *pPair -> first )  {
                     for( Collider *pSecond : *pPair -> second )  {
-                        if( pFirst -> Hit( pSecond -> GetDimension2D() ) )  {
+                        // Collider-to-Collider overload (not the
+                        // stDimension2D one) so both sides' own SetInset
+                        // shrink apply - passing pSecond->GetDimension2D()
+                        // here instead silently ignored pSecond's own
+                        // inset entirely, since only pFirst's side was
+                        // ever ran through GetEffectiveRect (see Hit(
+                        // Collider&)'s own doc comment in collider.cpp).
+                        if( pFirst -> Hit( *pSecond ) )  {
                             FireOnCollision( pFirst, pSecond );
                         }
                     }

--- a/tests/test_collider.cpp
+++ b/tests/test_collider.cpp
@@ -102,4 +102,78 @@ TEST_SUITE( "collision/Collider" )  {
         // Effective rect ends at x=40 - other starts at x=35, still inside it.
         CHECK( collider.Hit( other ) == true );
     }
+
+    // Hit(Collider&) - unlike Hit(stDimension2D&) above (which only ever
+    // applies "self"'s own inset against the other side's raw, full
+    // dimension - by design, since the other side there isn't necessarily
+    // a Collider at all), this overload applies BOTH colliders' own
+    // SetInset shrink. Regression coverage for a real bug found via
+    // Caravellius (2026-08-11): CollisionManager::Update() used to call
+    // the stDimension2D overload for it's collider-to-collider rule
+    // checks, which silently ignored the SECOND collider's own inset
+    // entirely - an enemy's own SetInset never took effect against a
+    // player bullet, however aggressively it was shrunk, purely because
+    // of which side of the rule pairing it happened to be registered on.
+
+    TEST_CASE( "Hit(Collider&) honors both colliders' own inset" )  {
+
+        Collider      first;
+        Collider      second;
+        stDimension2D firstDim  { { 0, 0 }, { 50, 50 } };
+        stDimension2D secondDim { { 45, 0 }, { 50, 50 } };
+
+        first.SetDimension2D( firstDim );
+        second.SetDimension2D( secondDim );
+
+        // Only "second"'s own inset shrinks it's own box - "first" is
+        // still it's full, un-inset 50x50. second's effective rect is
+        // (55,10)-(90,40) (10,10)-(40,40) offset by it's own (45,0)
+        // position - starts at x=55, past first's own right edge (x=50),
+        // so they no longer overlap even though their raw, full boxes
+        // still would (same setup as the "shrinks the collider's own
+        // side" test above, just on the "other" side of the pairing this
+        // time - the exact case Hit(stDimension2D&) could never express).
+        second.SetInset( 0.2f, 0.2f, 0.2f, 0.2f );
+
+        CHECK( first.Hit( second ) == false );
+
+        // Confirm it's genuinely second's own inset being honored, not
+        // some other effect - the same pair without it overlaps.
+        Collider second_no_inset;
+
+        second_no_inset.SetDimension2D( secondDim );
+
+        CHECK( first.Hit( second_no_inset ) == true );
+    }
+
+    TEST_CASE( "Hit(Collider&) still detects overlap within both shrunk boxes" )  {
+
+        Collider      first;
+        Collider      second;
+        stDimension2D firstDim  { { 0, 0 }, { 50, 50 } };
+        stDimension2D secondDim { { 35, 0 }, { 50, 50 } };
+
+        first.SetDimension2D( firstDim );
+        second.SetDimension2D( secondDim );
+        first.SetInset( 0.2f, 0.2f, 0.2f, 0.2f );
+        second.SetInset( 0.2f, 0.2f, 0.2f, 0.2f );
+
+        // first's effective rect ends at x=40; second's effective rect
+        // (35+10=45 to 35+40=75) starts at x=45 - past first's own x=40,
+        // so even with both sides properly shrunk this specific pair no
+        // longer overlaps (tighter than the single-sided-inset case
+        // above, exactly because now both edges moved inward).
+        CHECK( first.Hit( second ) == false );
+
+        // A closer pair, still with both sides shrunk, that does overlap.
+        stDimension2D closerDim { { 25, 0 }, { 50, 50 } };
+        Collider      closer;
+
+        closer.SetDimension2D( closerDim );
+        closer.SetInset( 0.2f, 0.2f, 0.2f, 0.2f );
+
+        // closer's effective rect starts at x=25+10=35, still inside
+        // first's own effective rect (ends at x=40).
+        CHECK( first.Hit( closer ) == true );
+    }
 }

--- a/tests/test_collisionmanager.cpp
+++ b/tests/test_collisionmanager.cpp
@@ -98,6 +98,41 @@ TEST_SUITE( "collision/CollisionManager" )  {
         CHECK( listener.colliderHits[0].second == &colliderB );
     }
 
+    TEST_CASE( "Update honors the SECOND collider's own SetInset, not just the first's" )  {
+
+        // Regression coverage for the actual Update() call site, not just
+        // Collider::Hit(Collider&) in isolation (see tests/test_collider.cpp)
+        // - guards against this line ever reverting back to calling
+        // pFirst->Hit(pSecond->GetDimension2D()), which would silently
+        // reintroduce the bug (that overload compiles fine too, it just
+        // ignores pSecond's own inset entirely). Mirrors the "fires
+        // OnCollision only for overlapping colliders" test above, but with
+        // an inset on colliderB (the SECOND/"pSecond" side of the rule)
+        // shrinking it away from colliderA - their raw, full-size boxes
+        // still overlap (0,0,50,50 vs 45,0,50,50), only colliderB's own
+        // inset-shrunk effective box (55,10)-(85,40) doesn't reach
+        // colliderA's (0,0)-(50,50) anymore.
+        MockTileMap             tileMap;
+        CollisionManager        manager( &tileMap );
+        TestCollisionListener   listener;
+        Collider                colliderA, colliderB;
+        stDimension2D           dimA { { 0, 0 },  { 50, 50 } };
+        stDimension2D           dimB { { 45, 0 }, { 50, 50 } };  // overlaps A's raw box
+
+        colliderA.SetDimension2D( dimA );
+        colliderB.SetDimension2D( dimB );
+        colliderB.SetInset( 0.2f, 0.2f, 0.2f, 0.2f );
+
+        manager.AddCollider( 0, &colliderA );
+        manager.AddCollider( 1, &colliderB );
+        manager.AddColliderToColliderRule( 0, 1 );
+        manager.AddCollisionListener( &listener );
+
+        manager.Update();
+
+        CHECK( listener.colliderHits.size() == 0 );
+    }
+
     TEST_CASE( "Update ignores colliders on layers with no rule between them" )  {
 
         MockTileMap             tileMap;


### PR DESCRIPTION
## Summary
- `CollisionManager::Update()`'s collider-to-collider rule check called `pFirst->Hit(pSecond->GetDimension2D())` - the `Hit(stDimension2D&)` overload only ever runs the *caller's* own inset through `GetEffectiveRect()`, then tests it against the raw, un-inset dimension it's handed. `pSecond`'s own `SetInset` was never consulted at all. Any collider registered as the second side of a `collision_add_rule` pairing had a completely dead `SetInset` against that rule - found via Caravellius, where a boss's head hitbox never responded to `SetInset` no matter how aggressively it was shrunk, purely because of which side of the rule it was registered on.
- Verified the root cause directly against the shipped `v0.6.0` source (not just the diff context) before touching anything.
- Adds `Collider::Hit(Collider&)`, which runs both sides through `GetEffectiveRect()` and tests those against each other, and switches `Update()`'s collider-to-collider check to use it. `Hit(stDimension2D&)` is untouched - still there for testing against an arbitrary rectangle that isn't itself a `Collider`.
- Two `Collider`-level tests cover `Hit(Collider&)` directly - hand-verified the AABB math against `RectRect`'s actual formula.
- One more test, at the `CollisionManager` level, mirrors the existing "fires OnCollision only for overlapping colliders" test but insets only the second collider - **confirmed this test actually catches the bug** by temporarily reverting the `Update()` fix locally and re-running it (`colliderHits.size()` was `1`, not `0`), then restored the fix and confirmed green. This guards the actual call site that had the bug, not just the new method in isolation.
- Bumps version to 0.7.0 (new public API - `Collider::Hit(Collider&)` - alongside the fix, MINOR per this project's pre-1.0 convention).

## Test plan
- [x] `cmake --build build --target sunlight_tests` builds clean, no warnings
- [x] `./build/tests/sunlight_tests` - 75/75 test cases, 2220/2220 assertions pass
- [x] New `CollisionManager`-level regression test verified to fail without the fix and pass with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)