### PR TITLE
Add font/text rendering primitives (SetFont, DrawText, MeasureText)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
-project (sunlight VERSION 0.8.0)
+project (sunlight VERSION 0.9.0)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/src/engines/iengine.h
+++ b/src/engines/iengine.h
@@ -128,6 +128,83 @@ namespace SunLight  {
                                               SunLight :: Base :: stColor color ) = 0;
 
             /**
+             * @brief Must be implemented to load (or replace) the font used
+             * by @see DrawText, from a font file on disk. Implementations
+             * are expected to support at least TrueType/OpenType and, where
+             * the backend's own font loader allows it, other formats too
+             * (e.g. raylib auto-detects an AngelCode BMFont ".fnt" atlas by
+             * extension) - callers pass a plain file path and rely on the
+             * backend to sort out the format, the same way @see LoadTexture
+             * doesn't ask the caller which image codec to use. Only
+             * meaningful to call once the window/render context exists.
+             * Until this is called for the first time, @see DrawText must
+             * fall back to the backend's own built-in default font, so text
+             * can be drawn with zero setup. Implementations must release
+             * whatever font this call is replacing (if it was a font this
+             * method loaded, not the backend's built-in default), so
+             * repeated calls don't leak font resources.
+             *
+             * @param szFilePath Path to the font file to load;
+             * @return true if the font loaded successfully and is now the
+             * active font, false if it failed to load (the previously
+             * active font, if any, is left untouched).
+             */
+            virtual bool SetFont( const char *szFilePath ) = 0;
+
+            /**
+             * @brief Must be implemented to draw a line of text on chosen
+             * target engine, in screen space - same as every other draw
+             * method on this interface, with no viewport/camera transform
+             * of its own, and using whichever font is currently active (see
+             * @see SetFont).
+             *
+             * @param szText The text to draw;
+             * @param nPosX X coordinate to draw at;
+             * @param nPosY Y coordinate to draw at;
+             * @param nFontSize Font size, in pixels;
+             * @param color Text color;
+             */
+            virtual void DrawText( const char *szText,
+                                   int nPosX,
+                                   int nPosY,
+                                   int nFontSize,
+                                   SunLight :: Base :: stColor color ) = 0;
+
+            /**
+             * @brief Must be implemented to measure how wide a line of
+             * text would render, in pixels, at a given font size, using
+             * whichever font is currently active (see @see SetFont) - the
+             * same font @see DrawText itself would use.
+             *
+             * @param szText The text to measure;
+             * @param nFontSize Font size, in pixels;
+             * @return The text's rendered width, in pixels;
+             */
+            virtual int MeasureText( const char *szText, int nFontSize ) = 0;
+
+            /**
+             * @brief Must be implemented to release any GPU-context-tied
+             * state this backend privately keeps (only a custom font
+             * loaded via @see SetFont, at the moment - see RaylibEngine's
+             * own implementation for why this exists), right before the
+             * window/render context is actually destroyed. This is NOT a
+             * general resource-teardown hook - textures/render targets
+             * loaded through this interface are still each caller's own
+             * responsibility to Unload; this exists purely for state a
+             * backend keeps privately that its own public API otherwise
+             * gives callers no way to release (SetFont has no matching
+             * "UnsetFont"), so it doesn't outlive the context it was
+             * created in.
+             *
+             * Called exactly once per window lifecycle, by
+             * TileMapRenderer::Stop(), immediately before the window/
+             * context is closed - implementations must not touch any
+             * backend draw/resource call after this point until a new
+             * window/context exists again.
+             */
+            virtual void OnWindowClosing( void ) = 0;
+
+            /**
              * @brief Must be implemented to return the directory the running
              * executable lives in (trailing separator included), so callers
              * can resolve resource paths relative to the binary instead of

--- a/src/engines/raylib/raylibengine.cpp
+++ b/src/engines/raylib/raylibengine.cpp
@@ -20,6 +20,12 @@
 
 #include "engines/raylib/raylibengine.h"
 
+// Extra spacing (in pixels) DrawTextEx adds between characters, on top of
+// whatever a font's own glyph metrics already provide - 0 means "use the
+// font as authored, no extra letter-spacing", the correct default for a
+// generic engine primitive with no per-call spacing parameter of it's own.
+#define __DEFAULT_TEXT_SPACING   0.0f
+
 namespace SunLight  {
     namespace Engines  {
         namespace Raylib  {
@@ -239,6 +245,101 @@ namespace SunLight  {
 
                 ::DrawRectangle( nPosX, nPosY, nWidth, nHeight,
                                 Color{ color.nRed, color.nGreen, color.nBlue, color.nAlpha } );
+            }
+
+            /**
+             * @brief Load (or replace) the font used by DrawText (see
+             * @see IEngine::SetFont). Forwards straight to raylib's own
+             * ::LoadFont, which auto-detects the font file's format from
+             * it's extension (TrueType/OpenType, or an AngelCode BMFont
+             * ".fnt" atlas) - this method has no format-specific logic of
+             * it's own. The previous custom font, if any, is unloaded only
+             * after the new one is confirmed valid, so a failed load never
+             * leaves DrawText without a usable font.
+             */
+            bool RaylibEngine :: SetFont( const char *szFilePath )  {
+
+                Font  newFont = ::LoadFont( szFilePath );
+
+                // On failure raylib's own ::LoadFont returns an all-zero,
+                // never-allocated Font (confirmed in raylib's own source -
+                // it only reaches a GPU upload on the success path), so
+                // there's nothing of newFont's to release here.
+                if( !::IsFontValid( newFont ) )
+                    return false;
+
+                if( m_bCustomFontLoaded )
+                    ::UnloadFont( m_CurrentFont );
+
+                m_CurrentFont       = newFont;
+                m_bCustomFontLoaded = true;
+
+                return true;
+            }
+
+            /**
+             * @brief The font DrawText/MeasureText should use right now -
+             * whichever one SetFont last loaded, or raylib's own built-in
+             * default font if SetFont has never been called (or every
+             * call to it so far has failed).
+             */
+            Font  RaylibEngine :: GetActiveFont( void )  {
+
+                return m_bCustomFontLoaded ? m_CurrentFont : ::GetFontDefault();
+            }
+
+            /**
+             * @brief Draw a line of text in screen space, using whichever
+             * font is currently active - the backend's own built-in
+             * default font until @see SetFont is called for the first
+             * time (see @see IEngine::DrawText).
+             */
+            void RaylibEngine :: DrawText( const char *szText,
+                                           int nPosX,
+                                           int nPosY,
+                                           int nFontSize,
+                                           SunLight :: Base :: stColor color )  {
+
+                ::DrawTextEx( GetActiveFont(), szText, Vector2{ ( float ) nPosX, ( float ) nPosY },
+                             ( float ) nFontSize, __DEFAULT_TEXT_SPACING,
+                             Color{ color.nRed, color.nGreen, color.nBlue, color.nAlpha } );
+            }
+
+            /**
+             * @brief Measure a line of text's rendered width, using
+             * whichever font is currently active - same font resolution
+             * as @see DrawText (see @see IEngine::MeasureText).
+             */
+            int RaylibEngine :: MeasureText( const char *szText, int nFontSize )  {
+
+                Vector2  size = ::MeasureTextEx( GetActiveFont(), szText,
+                                                 ( float ) nFontSize, __DEFAULT_TEXT_SPACING );
+
+                return ( int ) size.x;
+            }
+
+            /**
+             * @brief Release this class's own GPU-context-tied state
+             * before the window/context goes away (see @see
+             * IEngine::OnWindowClosing) - just the custom font tracking,
+             * at the moment. Deliberately does NOT call ::UnloadFont here
+             * first - not because the context is already gone (it isn't:
+             * this runs before CloseWindow() is even called, so the GL
+             * context is still fully valid at this point, an explicit
+             * unload would be perfectly safe here too), but because it
+             * would be redundant work for no benefit - CloseWindow()'s own
+             * teardown (rlglClose(), then ClosePlatform()'s
+             * glfwDestroyWindow()) discards the whole GL context
+             * immediately after this runs anyway, taking every GPU handle
+             * in it with it, including this one. This only clears this
+             * class's own bookkeeping, so a *future* window (if Start() is
+             * ever called again) doesn't inherit a stale handle pointing
+             * at a texture that no longer exists.
+             */
+            void RaylibEngine :: OnWindowClosing( void )  {
+
+                m_CurrentFont       = Font {};
+                m_bCustomFontLoaded = false;
             }
 
             /**

--- a/src/engines/raylib/raylibengine.h
+++ b/src/engines/raylib/raylibengine.h
@@ -62,6 +62,18 @@ namespace SunLight  {
                                           int nHeight,
                                           SunLight :: Base :: stColor color ) override;
 
+                bool SetFont( const char *szFilePath ) override;
+
+                void DrawText( const char *szText,
+                               int nPosX,
+                               int nPosY,
+                               int nFontSize,
+                               SunLight :: Base :: stColor color ) override;
+
+                int MeasureText( const char *szText, int nFontSize ) override;
+
+                void OnWindowClosing( void ) override;
+
                 std :: string GetApplicationDirectory( void ) override;
 
                 void SetFullscreen( bool bFullscreen ) override;
@@ -82,6 +94,20 @@ namespace SunLight  {
                                         SunLight :: Base :: stRectangle source,
                                         SunLight :: Base :: stRectangle dest,
                                         SunLight :: Base :: stColor tint ) override;
+
+                private:
+
+                // Shared by DrawText/MeasureText - the font either of them
+                // should use right now (see m_CurrentFont's own comment).
+                Font  GetActiveFont( void );
+
+                // Font currently used by DrawText, loaded via SetFont - only
+                // valid (and only ever Unload'd) when m_bCustomFontLoaded is
+                // true; otherwise DrawText falls back to raylib's own
+                // built-in GetFontDefault(), which this class never owns
+                // and must never Unload.
+                Font  m_CurrentFont       {};
+                bool  m_bCustomFontLoaded = false;
             };
         }
     }

--- a/src/renderer/tilemaprenderer.cpp
+++ b/src/renderer/tilemaprenderer.cpp
@@ -1490,6 +1490,67 @@ namespace SunLight {
         }
 
         /**
+         * @brief Load (or replace) the font used by @see DrawText (see
+         * @see ITileMap::SetFont). A thin pass-through to IEngine - unlike
+         * @see SetWindowResizeable, there's no pre-Start() path to support
+         * here (loading a font needs the render context IEngine's backend
+         * already requires), so this is always forwarded directly.
+         */
+        bool TileMapRenderer :: SetFont( const char *szFilePath )  {
+
+            return SunLight :: Engines :: EngineFactory :: GetEngine().SetFont( szFilePath );
+        }
+
+        /**
+         * @brief Draw a line of text in screen space (see
+         * @see ITileMap::DrawText). A thin pass-through to IEngine, same
+         * shape as @see SetFont.
+         */
+        void TileMapRenderer :: DrawText( const char *szText,
+                                          int nPosX,
+                                          int nPosY,
+                                          int nFontSize,
+                                          unsigned char nRed,
+                                          unsigned char nGreen,
+                                          unsigned char nBlue,
+                                          unsigned char nAlpha )  {
+
+            SunLight :: Engines :: EngineFactory :: GetEngine().DrawText( szText, nPosX, nPosY, nFontSize,
+                                          SunLight :: Base :: stColor { nRed, nGreen, nBlue, nAlpha } );
+        }
+
+        /**
+         * @brief Measure a line of text's rendered width (see
+         * @see ITileMap::MeasureText). A thin pass-through to IEngine,
+         * same shape as @see DrawText.
+         */
+        int TileMapRenderer :: MeasureText( const char *szText, int nFontSize )  {
+
+            return SunLight :: Engines :: EngineFactory :: GetEngine().MeasureText( szText, nFontSize );
+        }
+
+        /**
+         * @brief Return the engine's own fixed design/render resolution
+         * width (see @see ITileMap::GetWindowWidth). Pure state - m_fWindowWidth
+         * is set once, at construction, and never touched again (in
+         * particular, never updated on a live window resize - see it's
+         * own doc comment on ITileMap for why that's deliberate).
+         */
+        int TileMapRenderer :: GetWindowWidth( void )  {
+
+            return ( int ) m_fWindowWidth;
+        }
+
+        /**
+         * @brief Return the engine's own fixed design/render resolution
+         * height (see @see GetWindowWidth).
+         */
+        int TileMapRenderer :: GetWindowHeight( void )  {
+
+            return ( int ) m_fWindowHeight;
+        }
+
+        /**
          * Set layer parameters.
          * @param nLayerId The layer id to set layer parameters;
          * @param layer reference to layer parameters structure to set;
@@ -1945,6 +2006,13 @@ namespace SunLight {
                     SunLight :: Engines :: EngineFactory :: GetEngine().UnloadRenderTarget( m_pRenderTexture );
                     m_pRenderTexture = nullptr;
                 }
+
+                // Give the backend a chance to release any GPU-context-tied
+                // state it privately keeps (e.g. a custom font loaded via
+                // SetFont) before CloseWindow() tears down the context that
+                // state belongs to - see IEngine::OnWindowClosing's own
+                // comment for why this can't just be inferred/skipped.
+                SunLight :: Engines :: EngineFactory :: GetEngine().OnWindowClosing();
 
                 CloseWindow();
                 m_bIsStarted = false;

--- a/src/renderer/tilemaprenderer.h
+++ b/src/renderer/tilemaprenderer.h
@@ -265,6 +265,20 @@ namespace SunLight {
             void SetWindowTitle( const std :: string &strTitle );
             void SetScreenFade( float fAlpha );
 
+            // Text rendering
+            bool SetFont( const char *szFilePath );
+            void DrawText( const char *szText,
+                           int nPosX,
+                           int nPosY,
+                           int nFontSize,
+                           unsigned char nRed,
+                           unsigned char nGreen,
+                           unsigned char nBlue,
+                           unsigned char nAlpha );
+            int MeasureText( const char *szText, int nFontSize );
+            int GetWindowWidth( void );
+            int GetWindowHeight( void );
+
             // Layer management
             bool SetLayer( int nLayerId, SunLight :: TileMap :: stLayer& layer );
             bool SetLayer( const char *szLayerName, SunLight :: TileMap :: stLayer &layer );

--- a/src/tilemap/itilemap.h
+++ b/src/tilemap/itilemap.h
@@ -231,6 +231,88 @@ namespace SunLight {
             virtual bool GetWindowResizeable( void ) = 0;
 
             /**
+             * @brief Load (or replace) the font used by @link DrawText,
+             * from any backend-supported font file (at minimum TrueType/
+             * OpenType; the raylib backend also auto-detects an AngelCode
+             * BMFont ".fnt" atlas by extension - see IEngine::SetFont).
+             * Callers just pass a file path; which font formats are
+             * actually supported is entirely a backend concern, not
+             * something callers need to know about. Until this is called
+             * for the first time, @link DrawText falls back to the
+             * backend's own built-in default font, so text can be drawn
+             * with zero setup.
+             *
+             * @param szFilePath Path to the font file to load;
+             * @return true if the font loaded successfully and is now the
+             * active font, false if it failed to load (the previously
+             * active font, if any, is left untouched).
+             */
+            virtual bool SetFont( const char *szFilePath ) = 0;
+
+            /**
+             * @brief Draw a line of text on screen, in screen space (no
+             * viewport/camera transform, same as the FPS counter), using
+             * whichever font is currently active (see @link SetFont).
+             *
+             * @param szText The text to draw;
+             * @param nPosX X coordinate to draw at;
+             * @param nPosY Y coordinate to draw at;
+             * @param nFontSize Font size, in pixels;
+             * @param nRed Text color red channel (0-255);
+             * @param nGreen Text color green channel (0-255);
+             * @param nBlue Text color blue channel (0-255);
+             * @param nAlpha Text color alpha channel (0-255);
+             */
+            virtual void DrawText( const char *szText,
+                                   int nPosX,
+                                   int nPosY,
+                                   int nFontSize,
+                                   unsigned char nRed,
+                                   unsigned char nGreen,
+                                   unsigned char nBlue,
+                                   unsigned char nAlpha ) = 0;
+
+            /**
+             * @brief Measure how wide a line of text would render, in
+             * pixels, at a given font size, using whichever font is
+             * currently active (see @link SetFont) - the same font @link
+             * DrawText itself would use. Meant for screen-space HUD
+             * layout (e.g. right-aligning a score/lives readout), not for
+             * anything camera/viewport-aware.
+             *
+             * @param szText The text to measure;
+             * @param nFontSize Font size, in pixels;
+             * @return The text's rendered width, in pixels;
+             */
+            virtual int MeasureText( const char *szText, int nFontSize ) = 0;
+
+            /**
+             * @brief Return the engine's own fixed design/render
+             * resolution width, in pixels - the coordinate space @link
+             * DrawText and every other screen-space draw call (the FPS
+             * counter, the screen-fade overlay) operate in. This is
+             * constant for the lifetime of the app (set once, at
+             * construction) and deliberately NOT the actual, live OS
+             * window's pixel size, which can change independently (see
+             * IEngine::GetScreenWidth) - the engine always letterbox-
+             * scales this fixed resolution to fit whatever the real
+             * window size ends up being, so screen-space drawing (and HUD
+             * layout built on top of it) should always measure against
+             * this value, not the live window size.
+             *
+             * @return The render resolution width, in pixels;
+             */
+            virtual int GetWindowWidth( void ) = 0;
+
+            /**
+             * @brief Return the engine's own fixed design/render
+             * resolution height, in pixels (see @link GetWindowWidth).
+             *
+             * @return The render resolution height, in pixels;
+             */
+            virtual int GetWindowHeight( void ) = 0;
+
+            /**
              * Set layer parameters.
              * @param nLayerId The layer id to set layer parameters;
              * @param layer reference to layer parameters structure to set;

--- a/tests/mock_engine.h
+++ b/tests/mock_engine.h
@@ -48,6 +48,11 @@ class MockEngine : public SunLight :: Engines :: IEngine  {
     int                                 nGetApplicationDirectoryCalls = 0;
     int                                 nSetFullscreenCalls        = 0;
     int                                 nSetWindowResizeableCalls  = 0;
+    int                                 nSetFontCalls              = 0;
+    int                                 nDrawTextCalls             = 0;
+    int                                 nMeasureTextCalls          = 0;
+    int                                 nMeasureTextResult         = 0;
+    int                                 nOnWindowClosingCalls      = 0;
     int                                 nLoadRenderTargetCalls     = 0;
     int                                 nUnloadRenderTargetCalls   = 0;
     int                                 nBeginRenderTargetCalls    = 0;
@@ -67,6 +72,9 @@ class MockEngine : public SunLight :: Engines :: IEngine  {
     SunLight :: Base :: stColor         lastFilledRectangleColor   { 0, 0, 0, 0 };
     bool                                bFullscreen                = false;
     bool                                bWindowResizeable          = false;
+    bool                                bSetFontResult             = true;
+    std :: string                       strLastSetFontPath;
+    std :: string                       strLastDrawnText;
     int                                 nScreenWidthResult         = 0;
     int                                 nScreenHeightResult        = 0;
     SunLight :: Base :: TextureHandle   hLoadRenderTargetResult    = ( SunLight :: Base :: TextureHandle )  0x2;
@@ -137,6 +145,26 @@ class MockEngine : public SunLight :: Engines :: IEngine  {
     void SetWindowResizeable( bool bValue )  {
         nSetWindowResizeableCalls++;
         bWindowResizeable = bValue;
+    }
+
+    bool SetFont( const char *szFilePath )  {
+        nSetFontCalls++;
+        strLastSetFontPath = szFilePath;
+        return bSetFontResult;
+    }
+
+    void DrawText( const char *szText, int, int, int, SunLight :: Base :: stColor )  {
+        nDrawTextCalls++;
+        strLastDrawnText = szText;
+    }
+
+    int MeasureText( const char*, int )  {
+        nMeasureTextCalls++;
+        return nMeasureTextResult;
+    }
+
+    void OnWindowClosing( void )  {
+        nOnWindowClosingCalls++;
     }
 
     int GetScreenWidth( void )  {

--- a/tests/mock_tilemap.h
+++ b/tests/mock_tilemap.h
@@ -90,6 +90,24 @@ class MockTileMap : public SunLight :: TileMap :: ITileMap  {
         return false;
     }
 
+    bool SetFont( const char* )  {
+        return false;
+    }
+
+    void DrawText( const char*, int, int, int, unsigned char, unsigned char, unsigned char, unsigned char )  {}
+
+    int MeasureText( const char*, int )  {
+        return 0;
+    }
+
+    int GetWindowWidth( void )  {
+        return 0;
+    }
+
+    int GetWindowHeight( void )  {
+        return 0;
+    }
+
     bool SetLayer( int, SunLight :: TileMap :: stLayer& )  {
         return false;
     }


### PR DESCRIPTION
## Summary
- `SetFont`/`DrawText`/`MeasureText` on `IEngine` + `ITileMap`, for a real screen-space HUD. `SetFont` forwards straight to raylib's `LoadFont` (auto-detects TrueType/OpenType or an AngelCode BMFont `.fnt` atlas by extension); until called, text draws with the backend's built-in default font. Fails gracefully on a bad path - verified against raylib's own source that `LoadFont` returns an all-zero, never-allocated `Font` on failure, so there's nothing to release and the previous font is left untouched.
- `ITileMap::DrawText` takes flat `unsigned char` channels rather than `stColor`, matching `itilemap.h`'s existing convention of never depending on `base/color.h` (verified - zero hits). `IEngine::DrawText` uses `stColor` like every other draw primitive there.
- `ITileMap::GetWindowWidth/GetWindowHeight` - the engine's fixed design/render resolution, pure existing `TileMapRenderer` state, no new `IEngine` surface needed. Deliberately distinct from `IEngine::GetScreenWidth/Height` (the live, resizeable OS window size).
- `RaylibEngine` gains its first persistent state (`m_CurrentFont`, `m_bCustomFontLoaded`) and a matching lifecycle fix: `IEngine::OnWindowClosing()`, its first window-lifecycle hook, called once by `TileMapRenderer::Stop()` right before `CloseWindow()`, so a font loaded via `SetFont` doesn't leave a stale GPU handle behind if `Start()` is ever called again. Deliberately narrow - not a general teardown hook, just for backend-private state with no other release path.
- Reviewed and corrected one comment: the original draft justified skipping an explicit `UnloadFont()` in `OnWindowClosing()` by saying the context "may already be mid-teardown" - traced raylib's actual `CloseWindow()` sequence (`rlglClose()` then `ClosePlatform()`'s `glfwDestroyWindow()`) and confirmed the context is still fully valid at the point `OnWindowClosing()` runs (it's called *before* `CloseWindow()`). The decision to skip the explicit unload is fine either way (the context teardown that follows immediately reclaims it regardless), but the comment now states the real reason (redundant, not unsafe) instead of an inaccurate one.
- `MockEngine`/`MockTileMap` gain matching stubs.
- Bumps version to 0.9.0 (new public API, MINOR per this project's pre-1.0 convention).

## Test plan
- [x] `cmake --build build --target sunlight_tests` builds clean, no warnings
- [x] `./build/tests/sunlight_tests` - 77/77 test cases, 2226/2226 assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)