### PR TITLE
Fix ScriptProcessor holding raw deque iterators across Add() calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,24 @@ Both factories also expose a test-only override hook — `SoundFactory::SetCreat
 
 Internal containers/members that exclusively own heap-allocated data (e.g. `Sprite::m_Sequences`, `CollisionManager`'s rule lists, `SoundManager::m_SoundMap`, `TileMapRenderer::m_pInputHandler`/`m_AnimInfoList`/event handler lists) use `std::unique_ptr`, not raw `new`/`delete` pairs. Raw pointers remain only for genuinely non-owning references — back-pointers (`BaseCanvas::m_pParent`), externally-owned objects registered into a container (`Collider*` inside `CollisionManager`, `Sprite*`/`TextureCanvas*` handed to a manager by its caller), self-referential struct members (`GraphicObject::m_pDimension` can point to its own `m_Dimension`), and handles crossing a C API boundary (tmx callbacks, `TextureHandle`). When adding a new owning member, prefer `unique_ptr` over raw `new`/`delete` to match this convention — several real bugs (leaks, dangling pointers from `Clear()`-style methods that deleted contents without clearing the container) were found and fixed by this exact conversion.
 
+## Reviewing and testing changes
+
+### Doc comments must be verified, not just plausible
+
+This codebase's comments explain *why*, not just *what* — most non-trivial methods carry a paragraph justifying the design choice (see `IEngine::DrawFilledRectangle`, `Collider::SetInset`, `TileMapRenderer::SetCameraPosition`). Match that density in new code, but treat every "why" — especially one citing an external library's behavior or a language/standard guarantee — as a claim to verify, not a plausible-sounding assumption to write down. Two real examples from this project's history where the code was correct but the comment's stated reasoning wasn't:
+- A comment justified skipping an explicit `UnloadFont()` call by saying the GL context "may already be mid-teardown" — actually still fully valid at that point, since the call in question runs *before* `CloseWindow()`, not after.
+- A comment justified switching `ScriptProcessor` off raw `std::deque` iterators by saying the standard "only guarantees invalidating the past-the-end iterator" on `push_back()` — backwards for `std::deque` specifically: the standard invalidates *all* iterators on `push_back`/`push_front` (unlike `std::vector`), so the bug was UB on every platform, not a Windows/MSVC-only quirk.
+
+Both were caught by reading the actual vendored source (`build/_deps/raylib-src/src/` after a `FetchContent` configure) or double-checking the standard's actual wording, rather than trusting a write-up at face value. A wrong "why" is worse than none — it misleads whoever reads it next. Apply this same standard when *reviewing* a pasted diff/PR, not only when writing new code: re-derive or verify each factual claim it makes before agreeing with it.
+
+### What a PR needs before it's done
+
+- **Add doctest coverage for anything new that doesn't need a real window/display** (see `## Build` above for what that excludes). This includes pure logic, and — often missed — the parts of a window-touching feature that don't actually need a window, via the `MockEngineFixture`/`MockSound` seams (e.g. a setter's "don't call into `IEngine` before `Start()`" guard is fully testable with a mock even though the live-window branch isn't).
+- **A new pure virtual on `IEngine`/`ITileMap`/`ISound` requires updating the matching mock in the same change** (`tests/mock_engine.h`/`tests/mock_tilemap.h`/`tests/mock_sound.h`), or `sunlight_tests` won't compile. This has broken the build multiple times in this project's history — always check the mock header when touching an interface.
+- **A regression test for a bug fix has to be proven to actually catch the bug**, not just added and left green. Temporarily revert the fix, rerun that one test, confirm it fails, then restore the fix and confirm it passes again — a test that never demonstrably failed against the old code isn't verified coverage.
+- **Check every diff touching rendering/input/sound for a direct raylib (or future SDL) call outside its `*/raylib/` folder** — see "Backend abstraction pattern" above. The fix is always: add or reuse a method on the relevant interface, implement it in the `Raylib*` class, route the original call site through the matching factory instead of the raylib call directly.
+- Build and run the *full* suite (`./build/tests/sunlight_tests`) before calling a change done, not just the tests you touched.
+
 ## Known issues (tracked in `doc/`)
 - `doc/FIXME.txt`: access violation when map scroll goes past viewport boundaries.
 - `doc/TODO.txt`: no isometric/hexagonal map support; per-layer parallax scrolling and per-object property management (opacity/visible/position) not implemented; sprite/layer draw-order still being finished.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,17 +28,31 @@ adding a new source file, re-run `cmake -B build -S .` so the glob picks it up.
 
 ## Before submitting a PR
 
-- **Run the test suite** (`ctest --test-dir build` or
-  `./build/tests/sunlight_tests`) and confirm it's still green. Add test
-  coverage for new logic where practical — see `tests/mock_engine.h`,
-  `tests/mock_sound.h`, and `tests/mock_tilemap.h` for the mocking seams
-  (`EngineFactory::SetEngine()`, `SoundFactory::SetCreator()`) already
-  available for code that touches `IEngine`/`ISound`.
+- **Run the full test suite** (`ctest --test-dir build` or
+  `./build/tests/sunlight_tests`) and confirm it's still green — not just the
+  tests you touched. Add test coverage for new logic where practical — see
+  `tests/mock_engine.h`, `tests/mock_sound.h`, and `tests/mock_tilemap.h` for
+  the mocking seams (`EngineFactory::SetEngine()`, `SoundFactory::SetCreator()`)
+  already available for code that touches `IEngine`/`ISound`, including the
+  parts of a window-touching feature that don't actually need a window (a
+  guard clause, a state getter/setter) even when the feature as a whole isn't
+  fully testable.
+- **If you add a new pure virtual to `IEngine`/`ITileMap`/`ISound`, update the
+  matching mock in the same PR** (`tests/mock_engine.h`/`tests/mock_tilemap.h`/
+  `tests/mock_sound.h`) — otherwise `sunlight_tests` won't compile.
+- **If you're fixing a bug, verify your regression test actually catches it**:
+  temporarily revert the fix, confirm the new test fails, then restore the fix
+  and confirm it passes. A test that was never observed to fail against the
+  old code isn't verified coverage.
 - **Reset `BUILD_LIBRARY_SAMPLES`/`BUILD_LIBRARY_TESTS` to `OFF`** before
   committing if you turned them on locally — they default to `OFF` and PRs
   shouldn't change that.
 - Keep commits focused; a bug fix doesn't need an unrelated refactor riding
   along with it.
+
+See `CLAUDE.md`'s "Reviewing and testing changes" section for the fuller
+version of this (including why a comment's stated reasoning needs verifying,
+not just its code).
 
 ## Code conventions
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
-project (sunlight VERSION 0.9.0)
+project (sunlight VERSION 0.9.1)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/src/scripting/scriptprocessor.cpp
+++ b/src/scripting/scriptprocessor.cpp
@@ -123,7 +123,7 @@ namespace SunLight {
 
             m_CommandQueue.clear();
             m_CommandLabelMap.clear();
-            m_CurrentCommand = m_CommandQueue.begin();
+            m_nCurrentCommandIndex = 0;
         }
 
         /**
@@ -134,7 +134,7 @@ namespace SunLight {
          */
         bool ScriptProcessor :: Compile( void )  {
 
-            m_CurrentCommand = m_CommandQueue.begin();
+            m_nCurrentCommandIndex = 0;
 
             return ( !m_CommandQueue.empty() );
         }
@@ -146,20 +146,20 @@ namespace SunLight {
          */
         bool ScriptProcessor :: Run( void )  {
 
-            if( !m_CommandQueue.empty() && ( m_CurrentCommand != m_CommandQueue.end() ) )  {
-                
+            if( m_nCurrentCommandIndex < m_CommandQueue.size() )  {
+
                 if( !m_bWaitSpritesQueueEmpty )  {
                     /*
-                    * Command processing 
+                    * Command processing
                     */
-                    switch( ( *m_CurrentCommand ) -> cmd )  {
+                    switch( m_CommandQueue[m_nCurrentCommandIndex] -> cmd )  {
 
                         case WAIT_SPRITES_QUEUE_EMPTY :
                             m_bWaitSpritesQueueEmpty = true;
                             break;
 
                         case  WAIT_CMD :  {
-                            OneParmCommand   *pParm = ( OneParmCommand * ) *m_CurrentCommand;
+                            OneParmCommand   *pParm = ( OneParmCommand * ) m_CommandQueue[m_nCurrentCommandIndex];
                             uint64_t         nTime  = duration_cast<milliseconds> ( steady_clock :: now().time_since_epoch() ).count();
 
                             m_nWaitMilli = ( m_nWaitMilli != 0 ? m_nWaitMilli : nTime + pParm -> nParm );
@@ -172,19 +172,19 @@ namespace SunLight {
                         break;
                         
                         case MOVE_SPRITES_TO_SCREEN_CMD :  {
-                            OneParmCommand   *pParm = ( OneParmCommand * ) *m_CurrentCommand;
+                            OneParmCommand   *pParm = ( OneParmCommand * ) m_CommandQueue[m_nCurrentCommandIndex];
 
                             if( m_pListener != nullptr )
-                                m_pListener -> OnCommand( ( *m_CurrentCommand ) -> cmd, pParm -> nParm );
+                                m_pListener -> OnCommand( pParm -> cmd, pParm -> nParm );
                         }
                         break;
 
                         case LOOP_CMD :  {
-                            TwoParmsCommand   *pParm = ( TwoParmsCommand * ) *m_CurrentCommand;
+                            TwoParmsCommand   *pParm = ( TwoParmsCommand * ) m_CommandQueue[m_nCurrentCommandIndex];
 
                             /*
                              * A jump back from END_LOOP_CMD always overshoots
-                             * this command (the unconditional m_CurrentCommand++
+                             * this command (the unconditional m_nCurrentCommandIndex++
                              * below runs right after the jump too), landing on
                              * the first command of the loop body - so this case
                              * only ever runs once per loop, and nParm2 (the
@@ -192,20 +192,20 @@ namespace SunLight {
                              * counter here, never re-seed it.
                              */
                             pParm -> data.nCounter = pParm -> nParm2;
-                            m_CommandLabelMap.insert( std ::make_pair( pParm -> nParm1, m_CurrentCommand ) );
+                            m_CommandLabelMap.insert( std ::make_pair( pParm -> nParm1, m_nCurrentCommandIndex ) );
                         }
                         break;
 
                         case END_LOOP_CMD :  {
-                            OneParmCommand                  *pParm     = ( OneParmCommand * ) *m_CurrentCommand;
+                            OneParmCommand                  *pParm     = ( OneParmCommand * ) m_CommandQueue[m_nCurrentCommandIndex];
                             CommandLabelMap :: iterator     itLoopCmd  = m_CommandLabelMap.find( pParm ->nParm );
 
                             if( itLoopCmd != m_CommandLabelMap.end() )  {
-                                TwoParmsCommand *pLoopParm = ( TwoParmsCommand * ) ( *itLoopCmd -> second );
+                                TwoParmsCommand *pLoopParm = ( TwoParmsCommand * ) m_CommandQueue[itLoopCmd -> second];
 
                                 if( pLoopParm -> data.nCounter > 0 )  {
                                     pLoopParm -> data.nCounter--;
-                                    m_CurrentCommand = itLoopCmd -> second;
+                                    m_nCurrentCommandIndex = itLoopCmd -> second;
                                 }
                             }
                             else if( m_pListener != nullptr )  {
@@ -216,18 +216,18 @@ namespace SunLight {
                         break;
 
                         case LABEL_CMD :  {
-                            OneParmCommand   *pParm = ( OneParmCommand * ) *m_CurrentCommand;
+                            OneParmCommand   *pParm = ( OneParmCommand * ) m_CommandQueue[m_nCurrentCommandIndex];
 
-                            m_CommandLabelMap.insert( std ::make_pair( pParm -> nParm, m_CurrentCommand ) );
+                            m_CommandLabelMap.insert( std ::make_pair( pParm -> nParm, m_nCurrentCommandIndex ) );
                         }
                         break;
 
                         case GOTO_LABEL_CMD :  {
-                            OneParmCommand                  *pParm    = ( OneParmCommand * ) *m_CurrentCommand;
+                            OneParmCommand                  *pParm    = ( OneParmCommand * ) m_CommandQueue[m_nCurrentCommandIndex];
                             CommandLabelMap :: iterator     itLoopCmd = m_CommandLabelMap.find( pParm -> nParm );
 
                             if( itLoopCmd != m_CommandLabelMap.end() )  {
-                                m_CurrentCommand = itLoopCmd -> second;
+                                m_nCurrentCommandIndex = itLoopCmd -> second;
                             }
                             else if( m_pListener != nullptr )  {
                                 m_pListener -> OnError( "GOTO_LABEL_CMD: unknown label " +
@@ -241,13 +241,13 @@ namespace SunLight {
                         case PAUSE_SONG_CMD :
                         case RESUME_SONG_CMD:
                         case STOP_SONG_CMD  :  {
-                            OneParmCommand   *pParm = ( OneParmCommand * ) *m_CurrentCommand;
+                            OneParmCommand   *pParm = ( OneParmCommand * ) m_CommandQueue[m_nCurrentCommandIndex];
 
                             if( m_pListener != nullptr )
-                                m_pListener -> OnCommand( ( *m_CurrentCommand ) -> cmd, pParm -> nParm );
+                                m_pListener -> OnCommand( pParm -> cmd, pParm -> nParm );
                         }
                         break;
-                        
+
                         case PLAY_SONG_DIRECT_CMD  :  // Not handled by scripts
                         case PAUSE_SONG_DIRECT_CMD :
                         case RESUME_SONG_DIRECT_CMD:
@@ -255,7 +255,7 @@ namespace SunLight {
                         break;
                     }
 
-                    m_CurrentCommand++;
+                    m_nCurrentCommandIndex++;
                 }
 
                 return true;

--- a/src/scripting/scriptprocessor.h
+++ b/src/scripting/scriptprocessor.h
@@ -65,9 +65,12 @@ namespace SunLight {
         typedef std :: deque<BaseCommand*> CommandQueue;
 
         /**
-         * @brief Command reference map definition;
+         * @brief Command reference map definition. Values are indices into
+         * m_CommandQueue rather than iterators - see m_nCurrentCommandIndex's
+         * own comment for why a raw deque iterator isn't safe to hold across
+         * a later Add() call.
          */
-        typedef std :: map<uint16_t, CommandQueue :: iterator> CommandLabelMap;
+        typedef std :: map<uint16_t, size_t> CommandLabelMap;
 
         /**
          * @brief Script processor class implementation for script 
@@ -77,7 +80,29 @@ namespace SunLight {
 
             CommandQueue                             m_CommandQueue;
             CommandLabelMap                          m_CommandLabelMap;
-            CommandQueue :: iterator                 m_CurrentCommand;
+
+            /*
+             * Index into m_CommandQueue, not a raw std::deque<>::iterator.
+             * Unlike std::vector, the standard says std::deque::push_back()
+             * invalidates ALL iterators to the deque, not just the past-
+             * the-end one - only references/pointers to existing elements
+             * are guaranteed to survive. So holding m_CurrentCommand across
+             * a later Add() call was already undefined behavior on every
+             * platform, not a Windows-specific quirk; MSVC's checked/debug
+             * iterators (default in a Debug build) just happen to be the
+             * only one of the three that actually catch it, since libstdc++/
+             * libc++'s chunk-based deque implementations often don't move
+             * the specific element/chunk an existing iterator points at, so
+             * the dangling iterator "works" there until it doesn't. Add()
+             * being called again shortly after Clear() reset this (e.g.
+             * Caravellius's restart_game(): sp_clear() immediately followed
+             * by sp_load_stage()) tripped a "deque iterators incompatible"
+             * debug assertion on Windows, in Run()'s own m_CurrentCommand
+             * != m_CommandQueue.end() check. An index has no such hazard,
+             * and Clear()/Compile()'s existing begin()-reset semantics map
+             * directly onto index 0.
+             */
+            size_t                                    m_nCurrentCommandIndex;
             uint64_t                                 m_nWaitMilli;
             SunLight :: Scripting :: IScriptListener *m_pListener;
             bool                                     m_bWaitSpritesQueueEmpty;


### PR DESCRIPTION
## Summary
- `ScriptProcessor::m_CurrentCommand` was a raw `std::deque<BaseCommand*>::iterator`, and `CommandLabelMap` stored iterators too (for `LOOP_CMD`/`LABEL_CMD` jump targets). Both are invalidated by `std::deque::push_back()` per the standard - unlike `std::vector`, deque invalidates *all* iterators on `push_back`, not just the past-the-end one, so holding either across a later `Add()` call was already undefined behavior on every platform, not a Windows-specific quirk. It surfaced as a hard crash on Windows because MSVC's checked/debug iterators (default in a Debug build) are the only one of the three major STLs that actually catches it - libstdc++/libc++ often don't move the specific chunk an existing iterator points at, so the same dangling iterator silently "worked" there.
- Found via Caravellius: its restart flow calls `sp_clear()` immediately followed by `sp_load_stage()` - i.e. `Clear()` (resets `m_CurrentCommand` to `begin()`) immediately followed by `Add()` (`push_back`) - reliably tripped a "deque iterators incompatible" debug assertion in `Run()`'s own iterator-comparison check on every restart, on Windows only.
- Fixed by tracking position as a `size_t` index into `m_CommandQueue` instead. `std::deque` supports O(1) random access via `operator[]`, and this class only ever grows the queue at the back or `clear()`s it entirely (no `erase()`/`pop_front()`), so an index stays valid across any `Add()` call regardless of iterator-invalidation semantics. No public API change - both members are private.
- Corrected one inaccuracy in the original write-up's root-cause explanation before merging: it originally claimed the standard "only guarantees invalidating the past-the-end iterator" and that MSVC was being "stricter" - that's backwards for `std::deque` specifically. The code comment now states the actual guarantee.

## Test plan
- [x] `cmake --build build --target sunlight_tests` builds clean, no warnings
- [x] `./build/tests/sunlight_tests` - 77/77 test cases, 2226/2226 assertions pass
- [x] Existing `LOOP_CMD`/`END_LOOP_CMD`/`GOTO_LABEL_CMD`/`LABEL_CMD` tests in `test_scriptprocessor.cpp` exercise the changed `CommandLabelMap` logic directly and still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)