### PR TITLE
Add SetStretchToFill/GetStretchToFill for a no-letterbox blit mode

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
-project (sunlight VERSION 0.9.1)
+project (sunlight VERSION 0.10.0)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/src/renderer/tilemaprenderer.cpp
+++ b/src/renderer/tilemaprenderer.cpp
@@ -39,6 +39,7 @@
 #define __DEFAULT_CLEAR_BACKGROUND      true
 #define __DEFAULT_RESIZEABLE_STATUS     false
 #define __DEFAULT_DRAW_FPS_STATUS       false
+#define __DEFAULT_STRETCH_TO_FILL_STATUS false
 #define __DEFAULT_VIEW_CONTROL_MODE     VIEW_CONTROL_MODE_ACTIVE
 #define __DEFAULT_EXIT_KEY              SunLight :: Input :: KEY_ESCAPE
 #define __DEFAULT_WINDOW_BK_COLOR       0xFF000000
@@ -1080,6 +1081,7 @@ namespace SunLight {
             m_bWindowResizeable           = __DEFAULT_RESIZEABLE_STATUS;
             m_bClearBackground            = __DEFAULT_CLEAR_BACKGROUND;
             m_bDrawFPS                    = __DEFAULT_DRAW_FPS_STATUS;
+            m_bStretchToFill              = __DEFAULT_STRETCH_TO_FILL_STATUS;
             m_nScrollStepWidth            = __DEFAULT_SCROLL_STEP_WIDTH;
             m_nScrollStepHeight           = __DEFAULT_SCROLL_STEP_HEIGHT;
             m_ViewControlMode             = __DEFAULT_VIEW_CONTROL_MODE;
@@ -1224,6 +1226,30 @@ namespace SunLight {
         bool TileMapRenderer :: GetDrawFPS( void )  {
 
             return m_bDrawFPS;
+        }
+
+        /**
+         * Choose how the fixed-internal-resolution render target is
+         * blitted onto the real window/screen when their sizes differ -
+         * see ITileMap::SetStretchToFill's own doc comment for the full
+         * behavior. A plain flag read every frame in Run()'s own blit
+         * math, same as m_bDrawFPS - no immediate side effect needed here
+         * (unlike m_bWindowResizeable, which pokes IEngine right away if
+         * the window's already running).
+         * @param bStretchToFill The new stretch-to-fill status;
+         */
+        void TileMapRenderer :: SetStretchToFill( bool bStretchToFill )  {
+
+            m_bStretchToFill = bStretchToFill;
+        }
+
+        /**
+         * Query whether the render target is currently being stretched to
+         * fill (see @see SetStretchToFill).
+         */
+        bool TileMapRenderer :: GetStretchToFill( void )  {
+
+            return m_bStretchToFill;
         }
 
         /**
@@ -2063,29 +2089,54 @@ namespace SunLight {
 
                     /*
                      * Blit the fixed-resolution render texture to the real
-                     * window, scaled to fit and letterboxed (black bars) to
-                     * preserve aspect ratio - recomputed from the actual
-                     * current screen size every single frame, so both
-                     * fullscreen (SetFullscreen) and live window resizing
-                     * (if m_bWindowResizeable) fall out of this one path
-                     * with no separate resize-event handling needed.
-                     * Source height is negative because render targets are
+                     * window - recomputed from the actual current screen
+                     * size every single frame, so both fullscreen
+                     * (SetFullscreen) and live window resizing (if
+                     * m_bWindowResizeable) fall out of this one path with
+                     * no separate resize-event handling needed. Source
+                     * height is negative because render targets are
                      * stored bottom-up (OpenGL convention) - this flips it
                      * back right-side up. BeginDrawing/EndDrawing/
                      * ClearBackground/WindowShouldClose stay raylib-direct,
                      * same as the rest of this window's lifecycle.
+                     *
+                     * m_bStretchToFill (see it's own doc comment on
+                     * SetStretchToFill) picks between two different dest
+                     * rectangles: the default letterboxed one uses a
+                     * single uniform fScale (the smaller of the two axis
+                     * ratios) so the whole render target fits inside the
+                     * screen with it's own aspect ratio intact, centered
+                     * with black bars filling whatever's left over on the
+                     * non-fitting axis. Stretch-to-fill instead sizes dest
+                     * to the full screen directly, with no centering
+                     * offset needed - IEngine::DrawTextureScaled (raylib's
+                     * own DrawTexturePro underneath) already maps an
+                     * arbitrary source rect onto an arbitrary dest rect
+                     * using independent X/Y scale factors on it's own, so
+                     * this needs no change to that call itself, only to
+                     * which dest rectangle gets computed here.
                      */
                     int    nScreenWidth  = SunLight :: Engines :: EngineFactory :: GetEngine().GetScreenWidth();
                     int    nScreenHeight = SunLight :: Engines :: EngineFactory :: GetEngine().GetScreenHeight();
-                    float  fScaleX       = ( float ) nScreenWidth / m_fWindowWidth;
-                    float  fScaleY       = ( float ) nScreenHeight / m_fWindowHeight;
-                    float  fScale        = ( fScaleX < fScaleY ) ? fScaleX : fScaleY;
 
                     SunLight :: Base :: stRectangle  source { 0.0f, 0.0f, m_fWindowWidth, -m_fWindowHeight };
-                    SunLight :: Base :: stRectangle  dest   { ( nScreenWidth - ( m_fWindowWidth * fScale ) ) * 0.5f,
-                                                              ( nScreenHeight - ( m_fWindowHeight * fScale ) ) * 0.5f,
-                                                              m_fWindowWidth * fScale,
-                                                              m_fWindowHeight * fScale };
+                    SunLight :: Base :: stRectangle  dest;
+
+                    if( m_bStretchToFill )  {
+                        dest = SunLight :: Base :: stRectangle { 0.0f, 0.0f,
+                                                                  ( float ) nScreenWidth,
+                                                                  ( float ) nScreenHeight };
+                    }
+                    else  {
+                        float  fScaleX = ( float ) nScreenWidth / m_fWindowWidth;
+                        float  fScaleY = ( float ) nScreenHeight / m_fWindowHeight;
+                        float  fScale  = ( fScaleX < fScaleY ) ? fScaleX : fScaleY;
+
+                        dest = SunLight :: Base :: stRectangle { ( nScreenWidth - ( m_fWindowWidth * fScale ) ) * 0.5f,
+                                                                  ( nScreenHeight - ( m_fWindowHeight * fScale ) ) * 0.5f,
+                                                                  m_fWindowWidth * fScale,
+                                                                  m_fWindowHeight * fScale };
+                    }
 
                     BeginDrawing();
                     ClearBackground( BLACK );

--- a/src/renderer/tilemaprenderer.h
+++ b/src/renderer/tilemaprenderer.h
@@ -107,6 +107,7 @@ namespace SunLight {
             bool                                       m_bIsStarted;
             bool                                       m_bWindowResizeable;
             bool                                       m_bDrawFPS;
+            bool                                       m_bStretchToFill;
             static bool                                m_bInitialized;
 
             // Everything is rendered into this fixed-internal-resolution
@@ -233,6 +234,8 @@ namespace SunLight {
             bool GetDrawFPS( void );
             void SetFullscreen( bool bFullscreen );
             bool GetFullscreen( void );
+            void SetStretchToFill( bool bStretchToFill );
+            bool GetStretchToFill( void );
 
             // View port control
             void SetViewControlMode( SunLight :: Renderer :: ViewControlMode mode );

--- a/src/tilemap/itilemap.h
+++ b/src/tilemap/itilemap.h
@@ -231,6 +231,28 @@ namespace SunLight {
             virtual bool GetWindowResizeable( void ) = 0;
 
             /**
+             * @brief Choose how the fixed-internal-resolution render target
+             * is blitted onto the real window/screen when their sizes
+             * differ (fullscreen, or a live-resized window). false
+             * (default) preserves aspect ratio via a single uniform scale
+             * factor, letterboxing (black bars) whichever axis doesn't
+             * fill exactly. true stretches to fill the real window/screen
+             * completely instead, using independent X/Y scale factors -
+             * no black bars, but the image visibly warps whenever the
+             * window's own aspect ratio doesn't match the render target's.
+             *
+             * @param bStretchToFill true to stretch-fill (no letterboxing,
+             * may distort), false to letterbox (preserves aspect ratio);
+             */
+            virtual void SetStretchToFill( bool bStretchToFill ) = 0;
+
+            /**
+             * @brief Query whether the render target is currently being
+             * stretched to fill (see @link SetStretchToFill).
+             */
+            virtual bool GetStretchToFill( void ) = 0;
+
+            /**
              * @brief Load (or replace) the font used by @link DrawText,
              * from any backend-supported font file (at minimum TrueType/
              * OpenType; the raylib backend also auto-detects an AngelCode

--- a/tests/mock_tilemap.h
+++ b/tests/mock_tilemap.h
@@ -90,6 +90,12 @@ class MockTileMap : public SunLight :: TileMap :: ITileMap  {
         return false;
     }
 
+    void SetStretchToFill( bool )  {}
+
+    bool GetStretchToFill( void )  {
+        return false;
+    }
+
     bool SetFont( const char* )  {
         return false;
     }

--- a/tests/test_tilemaprenderer.cpp
+++ b/tests/test_tilemaprenderer.cpp
@@ -112,7 +112,7 @@ TEST_SUITE( "renderer/TileMapRenderer" )  {
         CHECK( renderer.RemoveSprite( 1, sprite ) == false );
     }
 
-    TEST_CASE( "GetDrawFPS/GetWindowResizeable round-trip what their setters last set" )  {
+    TEST_CASE( "GetDrawFPS/GetWindowResizeable/GetStretchToFill round-trip what their setters last set" )  {
 
         TileMapRenderer  renderer( 800, 600, "test", -1, false );
 
@@ -127,6 +127,12 @@ TEST_SUITE( "renderer/TileMapRenderer" )  {
 
         renderer.SetWindowResizeable( false );
         CHECK( renderer.GetWindowResizeable() == false );
+
+        renderer.SetStretchToFill( true );
+        CHECK( renderer.GetStretchToFill() == true );
+
+        renderer.SetStretchToFill( false );
+        CHECK( renderer.GetStretchToFill() == false );
     }
 
     TEST_CASE( "SetWindowResizeable before Start() only updates local state, never touches IEngine" )  {


### PR DESCRIPTION
## Summary
- `ITileMap::SetStretchToFill(bool)`/`GetStretchToFill()` toggle how the fixed-internal-resolution render target is blitted onto the real window/screen when their sizes differ. Default (`false`, unchanged) letterboxes via a single uniform scale factor; `true` sizes the destination rect to the full screen directly, stretching non-uniformly with no black bars.
- Verified the core claim - that `IEngine::DrawTextureScaled` (raylib's `DrawTexturePro` underneath) already supports independent X/Y scaling with no changes needed - directly against `rtextures.c`: dest width/height build the destination quad completely independently of source width/height. So this needed zero new `IEngine` surface, only which dest rectangle `Run()`'s existing blit computes.
- `MockTileMap` gains matching stubs.
- Extended the existing `GetDrawFPS`/`GetWindowResizeable` round-trip test to cover this pair too - it's a plain flag with no `IEngine` interaction at all (unlike `SetWindowResizeable`), so it was fully testable with zero window/mock dependencies and had no excuse to ship untested.
- Bumps version to 0.10.0 (new public API, MINOR per this project's pre-1.0 convention).

## Test plan
- [x] `cmake --build build --target sunlight_tests` builds clean, no warnings
- [x] `./build/tests/sunlight_tests` - 77/77 test cases, 2228/2228 assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)