### PR TITLE
Add ITileMap::DrawFilledRectangle for simple HUD elements

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
-project (sunlight VERSION 0.10.0)
+project (sunlight VERSION 0.11.0)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/src/renderer/tilemaprenderer.cpp
+++ b/src/renderer/tilemaprenderer.cpp
@@ -1546,6 +1546,24 @@ namespace SunLight {
         }
 
         /**
+         * @brief Draw a filled rectangle in screen space (see
+         * @see ITileMap::DrawFilledRectangle). A thin pass-through to
+         * IEngine, same shape as @see DrawText.
+         */
+        void TileMapRenderer :: DrawFilledRectangle( int nPosX,
+                                                     int nPosY,
+                                                     int nWidth,
+                                                     int nHeight,
+                                                     unsigned char nRed,
+                                                     unsigned char nGreen,
+                                                     unsigned char nBlue,
+                                                     unsigned char nAlpha )  {
+
+            SunLight :: Engines :: EngineFactory :: GetEngine().DrawFilledRectangle( nPosX, nPosY, nWidth, nHeight,
+                                          SunLight :: Base :: stColor { nRed, nGreen, nBlue, nAlpha } );
+        }
+
+        /**
          * @brief Measure a line of text's rendered width (see
          * @see ITileMap::MeasureText). A thin pass-through to IEngine,
          * same shape as @see DrawText.

--- a/src/renderer/tilemaprenderer.h
+++ b/src/renderer/tilemaprenderer.h
@@ -278,6 +278,14 @@ namespace SunLight {
                            unsigned char nGreen,
                            unsigned char nBlue,
                            unsigned char nAlpha );
+            void DrawFilledRectangle( int nPosX,
+                                      int nPosY,
+                                      int nWidth,
+                                      int nHeight,
+                                      unsigned char nRed,
+                                      unsigned char nGreen,
+                                      unsigned char nBlue,
+                                      unsigned char nAlpha );
             int MeasureText( const char *szText, int nFontSize );
             int GetWindowWidth( void );
             int GetWindowHeight( void );

--- a/src/tilemap/itilemap.h
+++ b/src/tilemap/itilemap.h
@@ -295,6 +295,37 @@ namespace SunLight {
                                    unsigned char nAlpha ) = 0;
 
             /**
+             * @brief Draw a filled, solid-color rectangle in screen space
+             * (no viewport/camera transform, same coordinate space as
+             * @link DrawText and the FPS counter) - meant for simple HUD
+             * elements (e.g. a progress/health bar) that don't warrant a
+             * whole sprite/texture asset. A thin pass-through to
+             * IEngine::DrawFilledRectangle, which already exists and is
+             * already used internally for the screen-fade overlay - this
+             * just exposes that same capability as it's own, arbitrary-
+             * position/size/color primitive rather than the fixed, full-
+             * window, single-alpha-value overlay @link ITileMap::SetScreenFade
+             * already covers.
+             *
+             * @param nPosX X coordinate of the rectangle's top-left corner;
+             * @param nPosY Y coordinate of the rectangle's top-left corner;
+             * @param nWidth Rectangle width, in pixels;
+             * @param nHeight Rectangle height, in pixels;
+             * @param nRed Fill color red channel (0-255);
+             * @param nGreen Fill color green channel (0-255);
+             * @param nBlue Fill color blue channel (0-255);
+             * @param nAlpha Fill color alpha channel (0-255);
+             */
+            virtual void DrawFilledRectangle( int nPosX,
+                                              int nPosY,
+                                              int nWidth,
+                                              int nHeight,
+                                              unsigned char nRed,
+                                              unsigned char nGreen,
+                                              unsigned char nBlue,
+                                              unsigned char nAlpha ) = 0;
+
+            /**
              * @brief Measure how wide a line of text would render, in
              * pixels, at a given font size, using whichever font is
              * currently active (see @link SetFont) - the same font @link

--- a/tests/mock_tilemap.h
+++ b/tests/mock_tilemap.h
@@ -102,6 +102,8 @@ class MockTileMap : public SunLight :: TileMap :: ITileMap  {
 
     void DrawText( const char*, int, int, int, unsigned char, unsigned char, unsigned char, unsigned char )  {}
 
+    void DrawFilledRectangle( int, int, int, int, unsigned char, unsigned char, unsigned char, unsigned char )  {}
+
     int MeasureText( const char*, int )  {
         return 0;
     }

--- a/tests/test_tilemaprenderer.cpp
+++ b/tests/test_tilemaprenderer.cpp
@@ -149,4 +149,56 @@ TEST_SUITE( "renderer/TileMapRenderer" )  {
         CHECK( renderer.GetWindowResizeable() == true );
         CHECK( fixture.engine.nSetWindowResizeableCalls == 0 );
     }
+
+    TEST_CASE( "DrawFilledRectangle forwards straight through to IEngine" )  {
+
+        MockEngineFixture  fixture;
+        TileMapRenderer    renderer( 800, 600, "test", -1, false );
+
+        renderer.DrawFilledRectangle( 10, 20, 30, 40, 255, 0, 0, 128 );
+
+        CHECK( fixture.engine.nDrawFilledRectangleCalls  == 1 );
+        CHECK( fixture.engine.nLastFilledRectangleX      == 10 );
+        CHECK( fixture.engine.nLastFilledRectangleY      == 20 );
+        CHECK( fixture.engine.nLastFilledRectangleWidth  == 30 );
+        CHECK( fixture.engine.nLastFilledRectangleHeight == 40 );
+        CHECK( fixture.engine.lastFilledRectangleColor.nRed   == 255 );
+        CHECK( fixture.engine.lastFilledRectangleColor.nGreen == 0 );
+        CHECK( fixture.engine.lastFilledRectangleColor.nBlue  == 0 );
+        CHECK( fixture.engine.lastFilledRectangleColor.nAlpha == 128 );
+    }
+
+    TEST_CASE( "DrawText forwards straight through to IEngine" )  {
+
+        MockEngineFixture  fixture;
+        TileMapRenderer    renderer( 800, 600, "test", -1, false );
+
+        renderer.DrawText( "score: 0", 5, 5, 16, 255, 255, 255, 255 );
+
+        CHECK( fixture.engine.nDrawTextCalls == 1 );
+        CHECK( fixture.engine.strLastDrawnText == "score: 0" );
+    }
+
+    TEST_CASE( "MeasureText forwards straight through to IEngine and returns its result" )  {
+
+        MockEngineFixture  fixture;
+        TileMapRenderer    renderer( 800, 600, "test", -1, false );
+
+        fixture.engine.nMeasureTextResult = 42;
+
+        CHECK( renderer.MeasureText( "score: 0", 16 ) == 42 );
+        CHECK( fixture.engine.nMeasureTextCalls == 1 );
+    }
+
+    TEST_CASE( "SetFont forwards straight through to IEngine and returns its result" )  {
+
+        MockEngineFixture  fixture;
+        TileMapRenderer    renderer( 800, 600, "test", -1, false );
+
+        fixture.engine.bSetFontResult = false;
+
+        CHECK( renderer.SetFont( "does-not-matter.ttf" ) == false );
+        CHECK( fixture.engine.nSetFontCalls == 1 );
+        CHECK( fixture.engine.strLastSetFontPath == "does-not-matter.ttf" );
+    }
 }


### PR DESCRIPTION
## Summary
- Exposes `IEngine::DrawFilledRectangle` (already used internally for the screen-fade overlay since v0.2.0) as its own general-purpose, arbitrary-position/size/color primitive on `ITileMap` - same shape as `DrawText`: screen space, no viewport/camera transform, thin one-line pass-through in `TileMapRenderer`. No new `IEngine` surface needed - verified `MockEngine` already fully tracks `DrawFilledRectangle` calls (unchanged since PR #67), so the claim that it needed no mock update checked out.
- `MockTileMap` gains a matching stub.
- **Closes a test-coverage gap this PR and the earlier font/text PR both shipped with**: `DrawFilledRectangle`, `DrawText`, `MeasureText`, and `SetFont` are all thin, unconditional `IEngine` pass-throughs with zero window/display dependency of their own, and `MockEngine` already tracks every parameter needed for all four - so none of them had any excuse to ship untested. Adds one `MockEngineFixture`-based pass-through test per method.
- Bumps version to 0.11.0 (new public API, MINOR per this project's pre-1.0 convention).

## Test plan
- [x] `cmake --build build --target sunlight_tests` builds clean, no warnings
- [x] `./build/tests/sunlight_tests` - 81/81 test cases, 2244/2244 assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)