### PR TITLE
Split screen-space/window-state primitives off ITileMap into IDrawSurface

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
-project (sunlight VERSION 0.11.0)
+project (sunlight VERSION 0.12.0)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/src/drawsurface/idrawsurface.h
+++ b/src/drawsurface/idrawsurface.h
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef __IDRAWSURFACE_H__
+#define __IDRAWSURFACE_H__
+
+#include <string>
+
+
+namespace SunLight {
+    namespace DrawSurface  {
+
+        /**
+         * @brief Screen-space drawing/window-state surface - every
+         * primitive here operates in screen space (no viewport/camera
+         * transform) and is independent of whether any tile map is
+         * currently loaded, unlike everything on @link
+         * SunLight::TileMap::ITileMap. Split out from ITileMap (which
+         * TileMapRenderer still also implements) once it became clear
+         * these had all ended up there for one reason only - ITileMap was
+         * the sole public interface a consumer could get a handle to,
+         * not because any of them are genuine tile-map operations; every
+         * one of these is a pure pass-through straight to IEngine
+         * underneath, with zero access to map data. Modeled after
+         * a GDI-style drawing surface/device-context object: something a
+         * caller draws directly onto, orthogonal to whatever "document"
+         * (here, a tile map) may or may not currently be loaded.
+         *
+         * A consumer holding only an IDrawSurface (not also an ITileMap)
+         * can draw text/shapes and query/toggle window state with no tile
+         * map ever having been loaded - the missing piece for genuinely
+         * mapless rendering is sprite drawing (@link
+         * SunLight::TileMap::ITileMap::AddSprite still requires a loaded
+         * map to resolve a layer id), not this.
+         */
+        class IDrawSurface {
+
+            public:
+
+            virtual ~IDrawSurface( void ) {};
+
+            /**
+             * @brief Set the application window's title, replacing whatever
+             * title it was created with.
+             *
+             * @param strTitle The new window title;
+             */
+            virtual void SetWindowTitle( const std :: string &strTitle ) = 0;
+
+            /**
+             * @brief Set a whole-screen fade overlay, drawn on top of every
+             * other rendered element (tilemap, sprites, everything) - not a
+             * per-texture effect.
+             *
+             * @param fAlpha Fade amount, 0.0 (fully visible, no overlay) to
+             * 1.0 (fully black);
+             */
+            virtual void SetScreenFade( float fAlpha ) = 0;
+
+            /**
+             * @brief Enter or leave fullscreen (borderless-windowed at the
+             * current monitor's native resolution). The game itself always
+             * renders at its own fixed internal resolution regardless of
+             * this setting - the renderer is responsible for scaling that
+             * up/down and letterboxing to whatever the actual window size
+             * ends up being.
+             *
+             * @param bFullscreen true to enter fullscreen, false to return
+             * to windowed mode;
+             */
+            virtual void SetFullscreen( bool bFullscreen ) = 0;
+
+            /**
+             * @brief Query whether the window is currently fullscreen (see
+             * @link SetFullscreen).
+             */
+            virtual bool GetFullscreen( void ) = 0;
+
+            /**
+             * @brief Show or hide the on-screen FPS counter, drawn at the
+             * top-left corner of the window every frame.
+             *
+             * @param bDrawFPS true to draw the FPS counter, false to hide it;
+             */
+            virtual void SetDrawFPS( bool bDrawFPS ) = 0;
+
+            /**
+             * @brief Query whether the FPS counter is currently being drawn
+             * (see @link SetDrawFPS).
+             */
+            virtual bool GetDrawFPS( void ) = 0;
+
+            /**
+             * @brief Allow or disallow the user resizing the application
+             * window by dragging its edges/corners. Safe to call both
+             * before the window is created (the initial state) and while
+             * it's already running (a genuine live toggle, in either
+             * direction).
+             *
+             * @param bResizeable true to allow resizing, false to disallow it;
+             */
+            virtual void SetWindowResizeable( bool bResizeable ) = 0;
+
+            /**
+             * @brief Query whether the window is currently resizeable (see
+             * @link SetWindowResizeable).
+             */
+            virtual bool GetWindowResizeable( void ) = 0;
+
+            /**
+             * @brief Choose how the fixed-internal-resolution render target
+             * is blitted onto the real window/screen when their sizes
+             * differ (fullscreen, or a live-resized window). false
+             * (default) preserves aspect ratio via a single uniform scale
+             * factor, letterboxing (black bars) whichever axis doesn't
+             * fill exactly. true stretches to fill the real window/screen
+             * completely instead, using independent X/Y scale factors -
+             * no black bars, but the image visibly warps whenever the
+             * window's own aspect ratio doesn't match the render target's.
+             *
+             * @param bStretchToFill true to stretch-fill (no letterboxing,
+             * may distort), false to letterbox (preserves aspect ratio);
+             */
+            virtual void SetStretchToFill( bool bStretchToFill ) = 0;
+
+            /**
+             * @brief Query whether the render target is currently being
+             * stretched to fill (see @link SetStretchToFill).
+             */
+            virtual bool GetStretchToFill( void ) = 0;
+
+            /**
+             * @brief Load (or replace) the font used by @link DrawText,
+             * from any backend-supported font file (at minimum TrueType/
+             * OpenType; the raylib backend also auto-detects an AngelCode
+             * BMFont ".fnt" atlas by extension - see IEngine::SetFont).
+             * Callers just pass a file path; which font formats are
+             * actually supported is entirely a backend concern, not
+             * something callers need to know about. Until this is called
+             * for the first time, @link DrawText falls back to the
+             * backend's own built-in default font, so text can be drawn
+             * with zero setup.
+             *
+             * @param szFilePath Path to the font file to load;
+             * @return true if the font loaded successfully and is now the
+             * active font, false if it failed to load (the previously
+             * active font, if any, is left untouched).
+             */
+            virtual bool SetFont( const char *szFilePath ) = 0;
+
+            /**
+             * @brief Draw a line of text on screen, in screen space (no
+             * viewport/camera transform, same as the FPS counter), using
+             * whichever font is currently active (see @link SetFont).
+             *
+             * @param szText The text to draw;
+             * @param nPosX X coordinate to draw at;
+             * @param nPosY Y coordinate to draw at;
+             * @param nFontSize Font size, in pixels;
+             * @param nRed Text color red channel (0-255);
+             * @param nGreen Text color green channel (0-255);
+             * @param nBlue Text color blue channel (0-255);
+             * @param nAlpha Text color alpha channel (0-255);
+             */
+            virtual void DrawText( const char *szText,
+                                   int nPosX,
+                                   int nPosY,
+                                   int nFontSize,
+                                   unsigned char nRed,
+                                   unsigned char nGreen,
+                                   unsigned char nBlue,
+                                   unsigned char nAlpha ) = 0;
+
+            /**
+             * @brief Draw a filled, solid-color rectangle in screen space
+             * (no viewport/camera transform, same coordinate space as
+             * @link DrawText and the FPS counter) - meant for simple HUD
+             * elements (e.g. a progress/health bar) that don't warrant a
+             * whole sprite/texture asset. A thin pass-through to
+             * IEngine::DrawFilledRectangle, which already exists and is
+             * already used internally for the screen-fade overlay - this
+             * just exposes that same capability as it's own, arbitrary-
+             * position/size/color primitive rather than the fixed, full-
+             * window, single-alpha-value overlay @link SetScreenFade
+             * already covers.
+             *
+             * @param nPosX X coordinate of the rectangle's top-left corner;
+             * @param nPosY Y coordinate of the rectangle's top-left corner;
+             * @param nWidth Rectangle width, in pixels;
+             * @param nHeight Rectangle height, in pixels;
+             * @param nRed Fill color red channel (0-255);
+             * @param nGreen Fill color green channel (0-255);
+             * @param nBlue Fill color blue channel (0-255);
+             * @param nAlpha Fill color alpha channel (0-255);
+             */
+            virtual void DrawFilledRectangle( int nPosX,
+                                              int nPosY,
+                                              int nWidth,
+                                              int nHeight,
+                                              unsigned char nRed,
+                                              unsigned char nGreen,
+                                              unsigned char nBlue,
+                                              unsigned char nAlpha ) = 0;
+
+            /**
+             * @brief Measure how wide a line of text would render, in
+             * pixels, at a given font size, using whichever font is
+             * currently active (see @link SetFont) - the same font @link
+             * DrawText itself would use. Meant for screen-space HUD
+             * layout (e.g. right-aligning a score/lives readout), not for
+             * anything camera/viewport-aware.
+             *
+             * @param szText The text to measure;
+             * @param nFontSize Font size, in pixels;
+             * @return The text's rendered width, in pixels;
+             */
+            virtual int MeasureText( const char *szText, int nFontSize ) = 0;
+
+            /**
+             * @brief Return the engine's own fixed design/render
+             * resolution width, in pixels - the coordinate space @link
+             * DrawText and every other screen-space draw call (the FPS
+             * counter, the screen-fade overlay) operate in. This is
+             * constant for the lifetime of the app (set once, at
+             * construction) and deliberately NOT the actual, live OS
+             * window's pixel size, which can change independently (see
+             * IEngine::GetScreenWidth) - the engine always letterbox-
+             * scales this fixed resolution to fit whatever the real
+             * window size ends up being, so screen-space drawing (and HUD
+             * layout built on top of it) should always measure against
+             * this value, not the live window size.
+             *
+             * @return The render resolution width, in pixels;
+             */
+            virtual int GetWindowWidth( void ) = 0;
+
+            /**
+             * @brief Return the engine's own fixed design/render
+             * resolution height, in pixels (see @link GetWindowWidth).
+             *
+             * @return The render resolution height, in pixels;
+             */
+            virtual int GetWindowHeight( void ) = 0;
+        };
+    }
+}
+
+#endif

--- a/src/engines/iengine.h
+++ b/src/engines/iengine.h
@@ -252,6 +252,18 @@ namespace SunLight  {
             virtual void SetWindowResizeable( bool bResizeable ) = 0;
 
             /**
+             * @brief Must be implemented to set the application window's
+             * title, replacing whatever title it was created with. Only
+             * meaningful to call once the window exists - callers are
+             * responsible for not calling this before that (see
+             * TileMapRenderer::SetWindowTitle, which guards the same way
+             * SetWindowResizeable's live-toggle path does).
+             *
+             * @param szTitle The new window title;
+             */
+            virtual void SetWindowTitle( const char *szTitle ) = 0;
+
+            /**
              * @brief Must be implemented to return the current width, in
              * pixels, of the actual window/screen on chosen target engine -
              * as opposed to any fixed internal rendering resolution a

--- a/src/engines/raylib/raylibengine.cpp
+++ b/src/engines/raylib/raylibengine.cpp
@@ -465,6 +465,18 @@ namespace SunLight  {
             }
 
             /**
+             * @brief Set the application window's title (see @see
+             * IEngine::SetWindowTitle). ::SetWindowTitle acts on the live
+             * window handle (glfwSetWindowTitle underneath, on the GLFW
+             * desktop backend), so this is only meaningful once the
+             * window already exists.
+             */
+            void RaylibEngine :: SetWindowTitle( const char *szTitle )  {
+
+                ::SetWindowTitle( szTitle );
+            }
+
+            /**
              * @brief Current window/screen width, in pixels.
              */
             int RaylibEngine :: GetScreenWidth( void )  {

--- a/src/engines/raylib/raylibengine.h
+++ b/src/engines/raylib/raylibengine.h
@@ -80,6 +80,7 @@ namespace SunLight  {
                 bool GetFullscreen( void ) override;
 
                 void SetWindowResizeable( bool bResizeable ) override;
+                void SetWindowTitle( const char *szTitle ) override;
 
                 int GetScreenWidth( void ) override;
                 int GetScreenHeight( void ) override;

--- a/src/renderer/tilemaprenderer.cpp
+++ b/src/renderer/tilemaprenderer.cpp
@@ -1231,7 +1231,7 @@ namespace SunLight {
         /**
          * Choose how the fixed-internal-resolution render target is
          * blitted onto the real window/screen when their sizes differ -
-         * see ITileMap::SetStretchToFill's own doc comment for the full
+         * see IDrawSurface::SetStretchToFill's own doc comment for the full
          * behavior. A plain flag read every frame in Run()'s own blit
          * math, same as m_bDrawFPS - no immediate side effect needed here
          * (unlike m_bWindowResizeable, which pokes IEngine right away if
@@ -1253,7 +1253,7 @@ namespace SunLight {
         }
 
         /**
-         * Enter or leave fullscreen (see @see ITileMap::SetFullscreen).
+         * Enter or leave fullscreen (see @see IDrawSurface::SetFullscreen).
          * Routed through IEngine rather than raylib directly, same as
          * every other window/render primitive TileMapRenderer uses.
          * @param bFullscreen true to enter fullscreen, false for windowed;
@@ -1493,7 +1493,12 @@ namespace SunLight {
 
         /**
          * @brief Set the application window's title, replacing whatever
-         * title it was created with.
+         * title it was created with (see @see IDrawSurface::SetWindowTitle).
+         * Routed through IEngine rather than raylib directly, same as
+         * every other window/render primitive TileMapRenderer uses -
+         * raylib's own SetWindowTitle acts on the live window handle, so
+         * this only forwards the call once the window actually exists,
+         * same guard as SetWindowResizeable.
          *
          * @param strTitle The new window title;
          */
@@ -1502,7 +1507,7 @@ namespace SunLight {
             m_strTitle = strTitle;
 
             if( m_bIsStarted )
-                :: SetWindowTitle( m_strTitle.c_str() );
+                SunLight :: Engines :: EngineFactory :: GetEngine().SetWindowTitle( m_strTitle.c_str() );
         }
 
         /**
@@ -1517,7 +1522,7 @@ namespace SunLight {
 
         /**
          * @brief Load (or replace) the font used by @see DrawText (see
-         * @see ITileMap::SetFont). A thin pass-through to IEngine - unlike
+         * @see IDrawSurface::SetFont). A thin pass-through to IEngine - unlike
          * @see SetWindowResizeable, there's no pre-Start() path to support
          * here (loading a font needs the render context IEngine's backend
          * already requires), so this is always forwarded directly.
@@ -1529,7 +1534,7 @@ namespace SunLight {
 
         /**
          * @brief Draw a line of text in screen space (see
-         * @see ITileMap::DrawText). A thin pass-through to IEngine, same
+         * @see IDrawSurface::DrawText). A thin pass-through to IEngine, same
          * shape as @see SetFont.
          */
         void TileMapRenderer :: DrawText( const char *szText,
@@ -1547,7 +1552,7 @@ namespace SunLight {
 
         /**
          * @brief Draw a filled rectangle in screen space (see
-         * @see ITileMap::DrawFilledRectangle). A thin pass-through to
+         * @see IDrawSurface::DrawFilledRectangle). A thin pass-through to
          * IEngine, same shape as @see DrawText.
          */
         void TileMapRenderer :: DrawFilledRectangle( int nPosX,
@@ -1565,7 +1570,7 @@ namespace SunLight {
 
         /**
          * @brief Measure a line of text's rendered width (see
-         * @see ITileMap::MeasureText). A thin pass-through to IEngine,
+         * @see IDrawSurface::MeasureText). A thin pass-through to IEngine,
          * same shape as @see DrawText.
          */
         int TileMapRenderer :: MeasureText( const char *szText, int nFontSize )  {
@@ -1575,7 +1580,7 @@ namespace SunLight {
 
         /**
          * @brief Return the engine's own fixed design/render resolution
-         * width (see @see ITileMap::GetWindowWidth). Pure state - m_fWindowWidth
+         * width (see @see IDrawSurface::GetWindowWidth). Pure state - m_fWindowWidth
          * is set once, at construction, and never touched again (in
          * particular, never updated on a live window resize - see it's
          * own doc comment on ITileMap for why that's deliberate).

--- a/src/renderer/tilemaprenderer.h
+++ b/src/renderer/tilemaprenderer.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include "collision/collisionmanager.h"
 #include "tilemap/itilemaplistener.h"
+#include "drawsurface/idrawsurface.h"
 #include "input/iinputhandler.h"
 #include "base/color.h"
 #include "base/primitives.h"
@@ -54,8 +55,13 @@ namespace SunLight {
 
         /**
          * @brief World renderer implementation to render TMX based maps.
+         * Also implements IDrawSurface directly (see it's own header
+         * comment) - the one concrete class both interfaces share, since
+         * it's the object that actually owns the window/render context
+         * both are ultimately backed by.
          */
-        class TileMapRenderer : public SunLight :: TileMap :: ITileMap  {
+        class TileMapRenderer : public SunLight :: TileMap :: ITileMap,
+                                 public SunLight :: DrawSurface :: IDrawSurface  {
 
             /**
              * Tile animation information.

--- a/src/tilemap/itilemap.h
+++ b/src/tilemap/itilemap.h
@@ -24,15 +24,25 @@
 #include "sprite/sprite.h"
 #include "input/iinputhandler.h"
 #include "collision/icollisionmanager.h"
-#include <string>
 
 
 namespace SunLight {
     namespace TileMap  {
 
         /**
-         * @brief TileMap interface with basic operations 
+         * @brief TileMap interface with basic operations
          * inside the game world.
+         *
+         * Screen-space drawing/window-state primitives (text, filled
+         * rectangles, screen fade, fullscreen/resizeable/stretch-to-fill
+         * toggles, window title, the fixed design-resolution getters)
+         * used to live here too - moved out to @link
+         * SunLight::DrawSurface::IDrawSurface once it became clear every
+         * one of them was a pure IEngine pass-through with zero access to
+         * map data, kept here only because ITileMap was the sole public
+         * interface a consumer could get a handle to. TileMapRenderer,
+         * the one concrete class implementing ITileMap, now also
+         * implements IDrawSurface directly.
          */
         class ITileMap : public SunLight :: Canvas :: BaseCanvas {
 
@@ -161,209 +171,6 @@ namespace SunLight {
              * currently shown at the viewport's top edge.
              */
             virtual void GetCameraPosition( int &nX, int &nY ) = 0;
-
-            /**
-             * @brief Set the application window's title, replacing whatever
-             * title it was created with.
-             *
-             * @param strTitle The new window title;
-             */
-            virtual void SetWindowTitle( const std :: string &strTitle ) = 0;
-
-            /**
-             * @brief Set a whole-screen fade overlay, drawn on top of every
-             * other rendered element (tilemap, sprites, everything) - not a
-             * per-texture effect.
-             *
-             * @param fAlpha Fade amount, 0.0 (fully visible, no overlay) to
-             * 1.0 (fully black);
-             */
-            virtual void SetScreenFade( float fAlpha ) = 0;
-
-            /**
-             * @brief Enter or leave fullscreen (borderless-windowed at the
-             * current monitor's native resolution). The game itself always
-             * renders at its own fixed internal resolution regardless of
-             * this setting - the renderer is responsible for scaling that
-             * up/down and letterboxing to whatever the actual window size
-             * ends up being.
-             *
-             * @param bFullscreen true to enter fullscreen, false to return
-             * to windowed mode;
-             */
-            virtual void SetFullscreen( bool bFullscreen ) = 0;
-
-            /**
-             * @brief Query whether the window is currently fullscreen (see
-             * @link SetFullscreen).
-             */
-            virtual bool GetFullscreen( void ) = 0;
-
-            /**
-             * @brief Show or hide the on-screen FPS counter, drawn at the
-             * top-left corner of the window every frame.
-             *
-             * @param bDrawFPS true to draw the FPS counter, false to hide it;
-             */
-            virtual void SetDrawFPS( bool bDrawFPS ) = 0;
-
-            /**
-             * @brief Query whether the FPS counter is currently being drawn
-             * (see @link SetDrawFPS).
-             */
-            virtual bool GetDrawFPS( void ) = 0;
-
-            /**
-             * @brief Allow or disallow the user resizing the application
-             * window by dragging its edges/corners. Safe to call both
-             * before the window is created (the initial state) and while
-             * it's already running (a genuine live toggle, in either
-             * direction).
-             *
-             * @param bResizeable true to allow resizing, false to disallow it;
-             */
-            virtual void SetWindowResizeable( bool bResizeable ) = 0;
-
-            /**
-             * @brief Query whether the window is currently resizeable (see
-             * @link SetWindowResizeable).
-             */
-            virtual bool GetWindowResizeable( void ) = 0;
-
-            /**
-             * @brief Choose how the fixed-internal-resolution render target
-             * is blitted onto the real window/screen when their sizes
-             * differ (fullscreen, or a live-resized window). false
-             * (default) preserves aspect ratio via a single uniform scale
-             * factor, letterboxing (black bars) whichever axis doesn't
-             * fill exactly. true stretches to fill the real window/screen
-             * completely instead, using independent X/Y scale factors -
-             * no black bars, but the image visibly warps whenever the
-             * window's own aspect ratio doesn't match the render target's.
-             *
-             * @param bStretchToFill true to stretch-fill (no letterboxing,
-             * may distort), false to letterbox (preserves aspect ratio);
-             */
-            virtual void SetStretchToFill( bool bStretchToFill ) = 0;
-
-            /**
-             * @brief Query whether the render target is currently being
-             * stretched to fill (see @link SetStretchToFill).
-             */
-            virtual bool GetStretchToFill( void ) = 0;
-
-            /**
-             * @brief Load (or replace) the font used by @link DrawText,
-             * from any backend-supported font file (at minimum TrueType/
-             * OpenType; the raylib backend also auto-detects an AngelCode
-             * BMFont ".fnt" atlas by extension - see IEngine::SetFont).
-             * Callers just pass a file path; which font formats are
-             * actually supported is entirely a backend concern, not
-             * something callers need to know about. Until this is called
-             * for the first time, @link DrawText falls back to the
-             * backend's own built-in default font, so text can be drawn
-             * with zero setup.
-             *
-             * @param szFilePath Path to the font file to load;
-             * @return true if the font loaded successfully and is now the
-             * active font, false if it failed to load (the previously
-             * active font, if any, is left untouched).
-             */
-            virtual bool SetFont( const char *szFilePath ) = 0;
-
-            /**
-             * @brief Draw a line of text on screen, in screen space (no
-             * viewport/camera transform, same as the FPS counter), using
-             * whichever font is currently active (see @link SetFont).
-             *
-             * @param szText The text to draw;
-             * @param nPosX X coordinate to draw at;
-             * @param nPosY Y coordinate to draw at;
-             * @param nFontSize Font size, in pixels;
-             * @param nRed Text color red channel (0-255);
-             * @param nGreen Text color green channel (0-255);
-             * @param nBlue Text color blue channel (0-255);
-             * @param nAlpha Text color alpha channel (0-255);
-             */
-            virtual void DrawText( const char *szText,
-                                   int nPosX,
-                                   int nPosY,
-                                   int nFontSize,
-                                   unsigned char nRed,
-                                   unsigned char nGreen,
-                                   unsigned char nBlue,
-                                   unsigned char nAlpha ) = 0;
-
-            /**
-             * @brief Draw a filled, solid-color rectangle in screen space
-             * (no viewport/camera transform, same coordinate space as
-             * @link DrawText and the FPS counter) - meant for simple HUD
-             * elements (e.g. a progress/health bar) that don't warrant a
-             * whole sprite/texture asset. A thin pass-through to
-             * IEngine::DrawFilledRectangle, which already exists and is
-             * already used internally for the screen-fade overlay - this
-             * just exposes that same capability as it's own, arbitrary-
-             * position/size/color primitive rather than the fixed, full-
-             * window, single-alpha-value overlay @link ITileMap::SetScreenFade
-             * already covers.
-             *
-             * @param nPosX X coordinate of the rectangle's top-left corner;
-             * @param nPosY Y coordinate of the rectangle's top-left corner;
-             * @param nWidth Rectangle width, in pixels;
-             * @param nHeight Rectangle height, in pixels;
-             * @param nRed Fill color red channel (0-255);
-             * @param nGreen Fill color green channel (0-255);
-             * @param nBlue Fill color blue channel (0-255);
-             * @param nAlpha Fill color alpha channel (0-255);
-             */
-            virtual void DrawFilledRectangle( int nPosX,
-                                              int nPosY,
-                                              int nWidth,
-                                              int nHeight,
-                                              unsigned char nRed,
-                                              unsigned char nGreen,
-                                              unsigned char nBlue,
-                                              unsigned char nAlpha ) = 0;
-
-            /**
-             * @brief Measure how wide a line of text would render, in
-             * pixels, at a given font size, using whichever font is
-             * currently active (see @link SetFont) - the same font @link
-             * DrawText itself would use. Meant for screen-space HUD
-             * layout (e.g. right-aligning a score/lives readout), not for
-             * anything camera/viewport-aware.
-             *
-             * @param szText The text to measure;
-             * @param nFontSize Font size, in pixels;
-             * @return The text's rendered width, in pixels;
-             */
-            virtual int MeasureText( const char *szText, int nFontSize ) = 0;
-
-            /**
-             * @brief Return the engine's own fixed design/render
-             * resolution width, in pixels - the coordinate space @link
-             * DrawText and every other screen-space draw call (the FPS
-             * counter, the screen-fade overlay) operate in. This is
-             * constant for the lifetime of the app (set once, at
-             * construction) and deliberately NOT the actual, live OS
-             * window's pixel size, which can change independently (see
-             * IEngine::GetScreenWidth) - the engine always letterbox-
-             * scales this fixed resolution to fit whatever the real
-             * window size ends up being, so screen-space drawing (and HUD
-             * layout built on top of it) should always measure against
-             * this value, not the live window size.
-             *
-             * @return The render resolution width, in pixels;
-             */
-            virtual int GetWindowWidth( void ) = 0;
-
-            /**
-             * @brief Return the engine's own fixed design/render
-             * resolution height, in pixels (see @link GetWindowWidth).
-             *
-             * @return The render resolution height, in pixels;
-             */
-            virtual int GetWindowHeight( void ) = 0;
 
             /**
              * Set layer parameters.

--- a/tests/mock_engine.h
+++ b/tests/mock_engine.h
@@ -48,6 +48,7 @@ class MockEngine : public SunLight :: Engines :: IEngine  {
     int                                 nGetApplicationDirectoryCalls = 0;
     int                                 nSetFullscreenCalls        = 0;
     int                                 nSetWindowResizeableCalls  = 0;
+    int                                 nSetWindowTitleCalls       = 0;
     int                                 nSetFontCalls              = 0;
     int                                 nDrawTextCalls             = 0;
     int                                 nMeasureTextCalls          = 0;
@@ -74,6 +75,7 @@ class MockEngine : public SunLight :: Engines :: IEngine  {
     bool                                bWindowResizeable          = false;
     bool                                bSetFontResult             = true;
     std :: string                       strLastSetFontPath;
+    std :: string                       strLastWindowTitle;
     std :: string                       strLastDrawnText;
     int                                 nScreenWidthResult         = 0;
     int                                 nScreenHeightResult        = 0;
@@ -145,6 +147,11 @@ class MockEngine : public SunLight :: Engines :: IEngine  {
     void SetWindowResizeable( bool bValue )  {
         nSetWindowResizeableCalls++;
         bWindowResizeable = bValue;
+    }
+
+    void SetWindowTitle( const char *szTitle )  {
+        nSetWindowTitleCalls++;
+        strLastWindowTitle = szTitle;
     }
 
     bool SetFont( const char *szFilePath )  {

--- a/tests/mock_tilemap.h
+++ b/tests/mock_tilemap.h
@@ -70,51 +70,13 @@ class MockTileMap : public SunLight :: TileMap :: ITileMap  {
         nX = 0;
         nY = 0;
     }
-    void SetWindowTitle( const std :: string& )  {}
-    void SetScreenFade( float )  {}
-    void SetFullscreen( bool )  {}
 
-    bool GetFullscreen( void )  {
-        return false;
-    }
-
-    void SetDrawFPS( bool )  {}
-
-    bool GetDrawFPS( void )  {
-        return false;
-    }
-
-    void SetWindowResizeable( bool )  {}
-
-    bool GetWindowResizeable( void )  {
-        return false;
-    }
-
-    void SetStretchToFill( bool )  {}
-
-    bool GetStretchToFill( void )  {
-        return false;
-    }
-
-    bool SetFont( const char* )  {
-        return false;
-    }
-
-    void DrawText( const char*, int, int, int, unsigned char, unsigned char, unsigned char, unsigned char )  {}
-
-    void DrawFilledRectangle( int, int, int, int, unsigned char, unsigned char, unsigned char, unsigned char )  {}
-
-    int MeasureText( const char*, int )  {
-        return 0;
-    }
-
-    int GetWindowWidth( void )  {
-        return 0;
-    }
-
-    int GetWindowHeight( void )  {
-        return 0;
-    }
+    // SetWindowTitle/SetScreenFade/SetFullscreen/GetFullscreen/SetDrawFPS/
+    // GetDrawFPS/SetWindowResizeable/GetWindowResizeable/SetStretchToFill/
+    // GetStretchToFill/SetFont/DrawText/DrawFilledRectangle/MeasureText/
+    // GetWindowWidth/GetWindowHeight moved off ITileMap onto the new
+    // IDrawSurface (see it's own header comment) - no longer part of this
+    // interface, so no longer stubbed here either.
 
     bool SetLayer( int, SunLight :: TileMap :: stLayer& )  {
         return false;

--- a/tests/test_tilemaprenderer.cpp
+++ b/tests/test_tilemaprenderer.cpp
@@ -150,6 +150,19 @@ TEST_SUITE( "renderer/TileMapRenderer" )  {
         CHECK( fixture.engine.nSetWindowResizeableCalls == 0 );
     }
 
+    TEST_CASE( "SetWindowTitle before Start() only updates local state, never touches IEngine" )  {
+
+        // Same gate as SetWindowResizeable above - IEngine::SetWindowTitle
+        // is only meaningful once the window exists (raylib's own
+        // SetWindowTitle acts on the live window handle).
+        MockEngineFixture  fixture;
+        TileMapRenderer    renderer( 800, 600, "test", -1, false );
+
+        renderer.SetWindowTitle( "new title" );
+
+        CHECK( fixture.engine.nSetWindowTitleCalls == 0 );
+    }
+
     TEST_CASE( "DrawFilledRectangle forwards straight through to IEngine" )  {
 
         MockEngineFixture  fixture;


### PR DESCRIPTION
## Summary
- Pulls every screen-space, map-independent primitive (text, filled rectangles, screen fade, fullscreen/resizeable/stretch-to-fill toggles, window title, the fixed design-resolution getters) off `ITileMap` and onto a new, standalone `IDrawSurface` interface. Every one of these was a pure `IEngine` pass-through with zero map access - they only lived on `ITileMap` because that was the one public interface a consumer could reach. `TileMapRenderer` now implements both interfaces directly; no method body changed, only which interface declares it.
- **Also fixes a real, pre-existing gap this split's own doc comment exposed**: `SetWindowTitle` called raylib's `::SetWindowTitle` directly, never routed through `IEngine` like every other primitive in this group - the one method that wasn't actually a pure `IEngine` pass-through as originally claimed. Adds `IEngine::SetWindowTitle` (implemented in `RaylibEngine`; only meaningful once the window exists, same as `SetWindowResizeable`, verified against raylib's source - `glfwSetWindowTitle` acts on the live window handle) and routes `TileMapRenderer::SetWindowTitle` through it with the same `m_bIsStarted` guard.
- `MockEngine` gains a `SetWindowTitle` stub; `MockTileMap` has all 16 moved methods' stubs removed, since they're no longer part of `ITileMap`.
- Confirmed no other `ITileMap` implementer exists in this repo, and - the risk that actually matters for a public-interface change like this - **verified against a live downstream Scarab rebuild**, clean.
- Adds a `MockEngineFixture`-based gate test for `SetWindowTitle`'s new `m_bIsStarted` guard, mirroring the existing `SetWindowResizeable` one - confirmed it actually fails if that guard is removed (temporarily dropped it locally, reran, watched it fail, restored it).
- Built and ran the full local verification this diff's scope called for: the library, all 5 samples, and `sunlight_tests`, not just the test suite alone - samples were the one place a moved method could have been reached through a bare `ITileMap&` (`ITileMapListener::OnUpdate`), confirmed clean.
- Bumps version to 0.12.0 (new public API + a breaking interface change, MINOR per this project's pre-1.0 convention).

## Test plan
- [x] `cmake --build build` (library + all 5 samples + tests) builds clean, no warnings
- [x] `./build/tests/sunlight_tests` - 82/82 test cases, 2245/2245 assertions pass
- [x] New `SetWindowTitle` gate-regression test verified to fail without the `m_bIsStarted` check and pass with it
- [x] Live Scarab rebuild confirmed clean by the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)