### PR TITLE
Allow AddSprite to register sprites with no map loaded

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
-project (sunlight VERSION 0.12.0)
+project (sunlight VERSION 0.13.0)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/src/renderer/tilemaprenderer.cpp
+++ b/src/renderer/tilemaprenderer.cpp
@@ -1939,13 +1939,36 @@ namespace SunLight {
         }
 
         /**
-         * Add a sprite to world on top of specified layer.
-         * @param nLayerId Id of an existing Layer on tiled map whose sprite will be added;
+         * Add a sprite to world on top of specified layer (see
+         * @see ITileMap::AddSprite's own doc comment for the full "why" -
+         * mapless-rendering support, added so a sprite can exist with no
+         * tile map ever loaded at all). GetLayer(nLayerId) validates
+         * nLayerId against the currently loaded map's own real layers
+         * when one is loaded (m_pTmxMap != nullptr) - unchanged from
+         * before. When no map is loaded, there's nothing real to validate
+         * nLayerId against, so it's skipped entirely and nLayerId is
+         * accepted as a plain caller-chosen grouping key - the same role
+         * it already plays for CollisionManager::AddCollider (a fixed-
+         * size array indexed by integer id, with zero tmx dependency) and
+         * Sprite::SetParent (accepts any BaseCanvas*, no tmx dependency
+         * either). Nothing below this check treats nLayerId any
+         * differently depending on which branch let it through.
+         *
+         * That said, AddCollider's own bounds check (nLayerId must be
+         * less than MAX_COLLIDER_LAYERS) still applies either way, and is
+         * now honored rather than ignored - a mapless caller is free to
+         * pick any nLayerId as a grouping key, but one at or past
+         * MAX_COLLIDER_LAYERS fails AddSprite outright instead of
+         * silently succeeding with a sprite whose collider never actually
+         * registered with the collision manager.
+         * @param nLayerId Id of an existing Layer on tiled map whose sprite will be added
+         * (or, with no map loaded, any caller-chosen grouping id, below
+         * MAX_COLLIDER_LAYERS);
          * @param sprite Reference to the sprite that will be added;
          */
         bool TileMapRenderer :: AddSprite( int nLayerId, SunLight :: Sprite :: Sprite& sprite )  {
 
-            if( m_bIsStarted && GetLayer( nLayerId ) )  {
+            if( m_bIsStarted && ( ( m_pTmxMap == nullptr ) || GetLayer( nLayerId ) ) )  {
                 SpriteMap :: iterator itItemLayer = m_SpriteMap.find( nLayerId );
 
                 if( itItemLayer == m_SpriteMap.end() )  {
@@ -1957,9 +1980,10 @@ namespace SunLight {
                                                                  itItemLayer -> second -> end(),
                                                                  &sprite );
 
-                    if( itItem == itItemLayer -> second -> end() )  {
+                    if( ( itItem == itItemLayer -> second -> end() ) &&
+                        m_CollisionManager.AddCollider( nLayerId, &sprite.GetCollider() ) )  {
+
                         sprite.SetParent( this );
-                        m_CollisionManager.AddCollider( nLayerId, &sprite.GetCollider() );
                         itItemLayer -> second -> push_back( &sprite );
                         return true;
                     }

--- a/src/tilemap/itilemap.h
+++ b/src/tilemap/itilemap.h
@@ -248,8 +248,22 @@ namespace SunLight {
             virtual SunLight :: Collision :: ICollisionManager& GetCollisionManager( void ) = 0;
 
             /**
-             * Add a sprite to world.
-             * @param nLayerId Id of Layer to add sprite;
+             * Add a sprite to world. A layer id is a purely logical
+             * grouping key (collision-manager grouping, viewport/zoom
+             * inheritance via Sprite::SetParent) - it doesn't need to
+             * resolve against any actual Tiled layer content. When no map
+             * is currently loaded at all, nLayerId is accepted as-is (no
+             * real layer to validate it against); when a map IS loaded,
+             * nLayerId must still name one of it's real layers, exactly
+             * as before - this only relaxes the no-map case, it doesn't
+             * loosen validation once a map exists. Either way, nLayerId
+             * must also be a valid collider-manager grouping key (below
+             * MAX_COLLIDER_LAYERS) - the sprite's own collider registration
+             * failing fails this call too, rather than succeeding with a
+             * sprite whose collider silently never got registered.
+             * @param nLayerId Id of Layer to add sprite (a real layer id
+             * if a map is loaded, or any caller-chosen grouping id if not,
+             * below MAX_COLLIDER_LAYERS either way);
              * @param sprite Reference to the sprite that will be added;
              */
             virtual bool AddSprite( int nLayerId, SunLight :: Sprite :: Sprite& sprite ) = 0;


### PR DESCRIPTION
## Summary
- Follow-up to the `IDrawSurface` split (v0.12.0), for mapless rendering - a title/cover screen shown before any real stage exists. Verified the actual scope directly against source: screen-space drawing (`IDrawSurface`) and the whole per-frame update loop were already mapless-capable; the one genuine blocker was `AddSprite`'s own `GetLayer(nLayerId)` check, which unconditionally fails via `tmx_find_layer_by_id` whenever `m_pTmxMap` is null - confirmed against libtmx's own source.
- `AddSprite` now skips that validation entirely when no map is loaded, accepting `nLayerId` as a caller-chosen grouping key - the same role it already plays for `CollisionManager::AddCollider` and `Sprite::SetParent`. Behavior with a map loaded is byte-for-byte unchanged.
- **Also fixes a related, previously-silent gap**: `AddSprite` discarded `CollisionManager::AddCollider`'s own return value, so a sprite could be reported as successfully added even when its collider silently failed to register (`AddCollider` bounds-checks against `MAX_COLLIDER_LAYERS`). Pre-existing, but became more reachable once `nLayerId` has no real-layer validation to fall back on in the mapless case. `AddSprite` now requires `AddCollider` to succeed before treating the sprite as added, with no side effects on failure.
- No public API signature changes anywhere.
- Neither change is independently unit-testable here - both require `m_bIsStarted == true`, reachable only via `Start()`, which calls raylib's `InitWindow()` directly (the one documented, not-yet-behind-`IEngine` exception). `AddCollider`'s own bounds-check behavior this now relies on is already directly covered in `test_collisionmanager.cpp`.
- Bumps version to 0.13.0 - covers both this change and the `backends/raylib` consolidation (#82), which merged without a version bump pending this discussion.

## Test plan
- [x] `cmake --build build --target sunlight_tests` builds clean, no warnings
- [x] `./build/tests/sunlight_tests` - 82/82 test cases, 2245/2245 assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)