### PR TITLE
Fix sprite rendering silently skipped on non-tile-layer/invisible layers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
-project (sunlight VERSION 0.13.0)
+project (sunlight VERSION 0.13.1)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/src/renderer/tilemaprenderer.cpp
+++ b/src/renderer/tilemaprenderer.cpp
@@ -671,8 +671,6 @@ namespace SunLight {
                     }
                 }
             }
-
-            HandleSpriteUpdate( pLayer -> id );
         }
 
         /**
@@ -700,6 +698,30 @@ namespace SunLight {
                             // TODO: FINISH HIM !!!
                             break;
                     }
+
+                    /*
+                     * Runtime-added sprites (AddSprite/m_SpriteMap, keyed by
+                     * this layer's own id) follow a parent-child visibility
+                     * hierarchy with their container TMX layer, by design: if
+                     * the layer itself is invisible, every sprite registered
+                     * against it is hidden too, full stop - a sprite's own
+                     * Sprite::SetVisible/GetVisible only ever gets a say once
+                     * it's container layer is already visible, same as any
+                     * scene-graph-style parent/child visibility. Previously
+                     * this only ran for the L_LAYER case (from inside
+                     * DrawLayer itself), so a sprite registered against an
+                     * L_OBJGR layer id was silently never drawn at all, even
+                     * when that layer WAS visible - moved here so every layer
+                     * type honors the same hierarchy consistently, not just
+                     * tile layers. A layer meant to host sprites but show no
+                     * static content of it's own (Caravellius's own "(Empty)"
+                     * placeholder layers - see that project's own
+                     * MAP_AUTHORING.md) must therefore be authored as
+                     * genuinely visible (omit `visible`, or `visible="1"`) -
+                     * `visible="0"` now means exactly what it says, hiding
+                     * that layer's sprites along with it's tiles/objects.
+                     */
+                    HandleSpriteUpdate( pLayer -> id );
                 }
 
                 pLayer = pLayer -> next;


### PR DESCRIPTION
## Summary
- `HandleSpriteUpdate(nLayerId)` - the call that actually issues a sprite's draw (`Sprite::Update()` -> `TextureCanvas::Update()` -> `IEngine::DrawTextureTiled`) - was only ever invoked from `DrawLayer`, the `L_LAYER`/real-tile-layer branch of `DrawAllLayers`'s per-layer-type dispatch. Never from `DrawObjects` (`L_OBJGR`), `DrawImageLayer` (`L_IMAGE`), or for a group layer's own id (`L_GROUP`) - confirmed by grepping every call site in the current source (there was exactly one).
- **Traced to `11f32d5`** (#29), which moved sprite updating from one flat, unconditional per-frame call to a per-layer mechanism tied to `DrawAllLayers`'s own dispatch, but only wired the new call into the tile-layer branch - confirmed directly via `git show 11f32d5`.
- Any sprite registered against a non-tile-layer id (e.g. an `<objectgroup>` used purely as an empty placeholder bucket for runtime-added sprites) silently never drew at all, regardless of that layer's visibility.
- Fix moves the `HandleSpriteUpdate` call to a single site inside `DrawAllLayers` itself, run for every layer type, still inside the existing `if(pLayer->visible)` gate - establishing a deliberate parent-child visibility hierarchy (a layer's own `visible` flag gates every sprite registered against it, same as its static content). This is a more complete fix than patching `DrawObjects` alone would have been - it also covers `L_IMAGE` and a group layer's own direct id, neither of which called `HandleSpriteUpdate` before either.
- Not independently unit-testable here - genuinely needs a real window/GL context (`DrawLayer` calls `DrawTile`, `RenderMap` calls raylib's `ClearBackground`/`DrawFPS` directly), unlike the isolated single-hop pass-throughs where this thread has found addable coverage before. Verified live instead via temporary instrumentation (removed before this commit): before the fix, `HandleSpriteUpdate` fired only for the one real tile layer across a 20s gameplay session with enemies actively spawning; after, correctly for every registered layer, confirmed in both visibility directions.
- Bumps version to 0.13.1 (pure internal fix, no public API/signature change - PATCH per this project's convention).

## Test plan
- [x] `cmake --build build --target sunlight_tests` builds clean, no warnings
- [x] `./build/tests/sunlight_tests` - 82/82 test cases, 2245/2245 assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)