### PR TITLE
Use real fullscreen instead of borderless-windowed (fixes macOS Dock overlap)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
-project (sunlight VERSION 0.13.1)
+project (sunlight VERSION 0.13.2)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/src/backends/raylib/raylibengine.cpp
+++ b/src/backends/raylib/raylibengine.cpp
@@ -426,17 +426,30 @@ namespace SunLight  {
             }
 
             /**
-             * @brief Enter or leave fullscreen. Uses raylib's borderless-
-             * windowed mode (not the older exclusive ToggleFullscreen(),
-             * which changes the monitor's own video mode and is markedly
-             * less reliable across platforms/window managers) - the window
-             * simply resizes to the current monitor's native resolution.
+             * @brief Enter or leave fullscreen. Uses raylib's real,
+             * exclusive ToggleFullscreen() (which changes the monitor's
+             * own video mode), not the borderless-windowed mode this used
+             * to use - switched 2026-08-26 after a real, live-confirmed
+             * problem with borderless-windowed on macOS: since it's an
+             * ordinary window merely resized to cover the full screen
+             * (not a genuine OS-level fullscreen space), the macOS Dock -
+             * when set to always show rather than auto-hide - still draws
+             * on top of it, visibly covering the bottom of the window.
+             * True ToggleFullscreen() enters a real fullscreen space,
+             * which macOS itself hides the Dock/menu bar behind
+             * automatically, matching what a player actually expects from
+             * a fullscreen game. Confirmed via a live A/B test that this
+             * genuinely fixes the Dock overlap with no visible mode-switch
+             * flicker or resolution/scaling artifacts on the platform this
+             * was tested on (previously the reason borderless-windowed was
+             * chosen instead) - worth re-verifying on any platform where a
+             * true video-mode switch could still misbehave differently.
              * @param bFullscreen true to enter fullscreen, false for windowed;
              */
             void RaylibEngine :: SetFullscreen( bool bFullscreen )  {
 
-                if( bFullscreen != ::IsWindowState( FLAG_BORDERLESS_WINDOWED_MODE ) )
-                    ::ToggleBorderlessWindowed();
+                if( bFullscreen != ::IsWindowState( FLAG_FULLSCREEN_MODE ) )
+                    ::ToggleFullscreen();
             }
 
             /**
@@ -445,7 +458,7 @@ namespace SunLight  {
              */
             bool RaylibEngine :: GetFullscreen( void )  {
 
-                return ::IsWindowState( FLAG_BORDERLESS_WINDOWED_MODE );
+                return ::IsWindowState( FLAG_FULLSCREEN_MODE );
             }
 
             /**

--- a/src/drawsurface/idrawsurface.h
+++ b/src/drawsurface/idrawsurface.h
@@ -75,8 +75,9 @@ namespace SunLight {
             virtual void SetScreenFade( float fAlpha ) = 0;
 
             /**
-             * @brief Enter or leave fullscreen (borderless-windowed at the
-             * current monitor's native resolution). The game itself always
+             * @brief Enter or leave fullscreen (a real, OS-level
+             * fullscreen space - see RaylibEngine::SetFullscreen for why
+             * this isn't borderless-windowed). The game itself always
              * renders at its own fixed internal resolution regardless of
              * this setting - the renderer is responsible for scaling that
              * up/down and letterboxing to whatever the actual window size


### PR DESCRIPTION
## Problem

`RaylibEngine::SetFullscreen` used raylib's `ToggleBorderlessWindowed()` — the window is simply resized to the current monitor's native resolution, not a genuine OS-level fullscreen space. On macOS, when the Dock is set to always show (not auto-hide), it still draws on top of the window regardless of size, visibly covering the bottom of the game.

## Fix

Switch to real `ToggleFullscreen()`, which enters a genuine fullscreen space that macOS itself hides the Dock/menu bar behind automatically.

## Verified

- Confirmed both `ToggleFullscreen()`/`ToggleBorderlessWindowed()` live in raylib's shared `platforms/rcore_desktop_glfw.c` (same code path on Windows/macOS/Linux, not macOS-specific).
- Live A/B test on macOS: Dock overlap gone, no visible mode-switch flicker or scaling artifacts.
- Full test suite green (82/82).

## Known open risk — not yet verified on Windows/Linux

`ToggleFullscreen()` performs a genuine monitor video-mode switch to the *window's current size* (GLFW's own `glfwSetWindowMonitor` doc: "updates the width, height and refresh rate of the desired video mode and switches to the video mode closest to it") — unlike `ToggleBorderlessWindowed()`, which explicitly resizes to the monitor's *native* resolution regardless of window size. Since this engine calls `InitWindow(m_fWindowWidth, m_fWindowHeight, ...)` at the game's own configured design resolution, a mismatch against the player's monitor's native resolution could trigger an actual display video-mode change on Windows/Linux — plausibly the original reason borderless-windowed was chosen. Being verified on Windows/Linux separately; will follow up with a fix if it misbehaves there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)