### PR TITLE
Add FullscreenStrategy parameter to SetFullscreen, defaulting to real fullscreen

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
-project (sunlight VERSION 0.13.2)
+project (sunlight VERSION 0.14.0)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/src/backends/raylib/raylibengine.cpp
+++ b/src/backends/raylib/raylibengine.cpp
@@ -426,39 +426,62 @@ namespace SunLight  {
             }
 
             /**
-             * @brief Enter or leave fullscreen. Uses raylib's real,
+             * @brief Enter or leave fullscreen. Defaults to raylib's real,
              * exclusive ToggleFullscreen() (which changes the monitor's
-             * own video mode), not the borderless-windowed mode this used
-             * to use - switched 2026-08-26 after a real, live-confirmed
-             * problem with borderless-windowed on macOS: since it's an
-             * ordinary window merely resized to cover the full screen
-             * (not a genuine OS-level fullscreen space), the macOS Dock -
-             * when set to always show rather than auto-hide - still draws
-             * on top of it, visibly covering the bottom of the window.
-             * True ToggleFullscreen() enters a real fullscreen space,
-             * which macOS itself hides the Dock/menu bar behind
-             * automatically, matching what a player actually expects from
-             * a fullscreen game. Confirmed via a live A/B test that this
-             * genuinely fixes the Dock overlap with no visible mode-switch
-             * flicker or resolution/scaling artifacts on the platform this
-             * was tested on (previously the reason borderless-windowed was
-             * chosen instead) - worth re-verifying on any platform where a
-             * true video-mode switch could still misbehave differently.
+             * own video mode) rather than the borderless-windowed mode
+             * this used to use unconditionally - switched 2026-08-26 after
+             * a real, live-confirmed problem with borderless-windowed on
+             * macOS: since it's an ordinary window merely resized to
+             * cover the full screen (not a genuine OS-level fullscreen
+             * space), the macOS Dock - when set to always show rather
+             * than auto-hide - still draws on top of it, visibly covering
+             * the bottom of the window. True ToggleFullscreen() enters a
+             * real fullscreen space, which macOS itself hides the
+             * Dock/menu bar behind automatically, matching what a player
+             * actually expects from a fullscreen game. Confirmed via a
+             * live A/B test that this genuinely fixes the Dock overlap
+             * with no visible mode-switch flicker or resolution/scaling
+             * artifacts on the platform this was tested on.
+             *
+             * FULLSCREEN_STRATEGY_BORDERLESS_WINDOWED is kept available as
+             * a fallback: unlike real ToggleFullscreen() (which switches
+             * the monitor's actual video mode to the window's current
+             * size, per GLFW's own glfwSetWindowMonitor() documentation),
+             * borderless-windowed explicitly resizes to the monitor's
+             * native resolution instead - safer on any platform/window
+             * manager where a true video-mode switch misbehaves,
+             * especially if the window's own size doesn't already match
+             * the player's monitor.
+             *
+             * Switching strategy while already fullscreen in the other
+             * one is unsupported (see IEngine::SetFullscreen) - both
+             * raylib toggles assume theirs is the only active fullscreen
+             * strategy, so mixing them without returning to windowed mode
+             * first can leave stale window flags set.
              * @param bFullscreen true to enter fullscreen, false for windowed;
+             * @param strategy Which fullscreen strategy to use when
+             * entering fullscreen (ignored when bFullscreen is false);
              */
-            void RaylibEngine :: SetFullscreen( bool bFullscreen )  {
+            void RaylibEngine :: SetFullscreen( bool bFullscreen, FullscreenStrategy strategy )  {
 
-                if( bFullscreen != ::IsWindowState( FLAG_FULLSCREEN_MODE ) )
-                    ::ToggleFullscreen();
+                if( strategy == FULLSCREEN_STRATEGY_BORDERLESS_WINDOWED )  {
+                    if( bFullscreen != ::IsWindowState( FLAG_BORDERLESS_WINDOWED_MODE ) )
+                        ::ToggleBorderlessWindowed();
+                }
+                else  {
+                    if( bFullscreen != ::IsWindowState( FLAG_FULLSCREEN_MODE ) )
+                        ::ToggleFullscreen();
+                }
             }
 
             /**
-             * @brief Query whether the window is currently fullscreen (see
-             * @see SetFullscreen).
+             * @brief Query whether the window is currently fullscreen,
+             * regardless of which strategy is active (see @see
+             * SetFullscreen).
              */
             bool RaylibEngine :: GetFullscreen( void )  {
 
-                return ::IsWindowState( FLAG_FULLSCREEN_MODE );
+                return ::IsWindowState( FLAG_FULLSCREEN_MODE ) || ::IsWindowState( FLAG_BORDERLESS_WINDOWED_MODE );
             }
 
             /**

--- a/src/backends/raylib/raylibengine.h
+++ b/src/backends/raylib/raylibengine.h
@@ -76,7 +76,7 @@ namespace SunLight  {
 
                 std :: string GetApplicationDirectory( void ) override;
 
-                void SetFullscreen( bool bFullscreen ) override;
+                void SetFullscreen( bool bFullscreen, FullscreenStrategy strategy = FULLSCREEN_STRATEGY_REAL ) override;
                 bool GetFullscreen( void ) override;
 
                 void SetWindowResizeable( bool bResizeable ) override;

--- a/src/drawsurface/idrawsurface.h
+++ b/src/drawsurface/idrawsurface.h
@@ -22,6 +22,7 @@
 #define __IDRAWSURFACE_H__
 
 #include <string>
+#include "engines/iengine.h"
 
 
 namespace SunLight {
@@ -75,22 +76,33 @@ namespace SunLight {
             virtual void SetScreenFade( float fAlpha ) = 0;
 
             /**
-             * @brief Enter or leave fullscreen (a real, OS-level
-             * fullscreen space - see RaylibEngine::SetFullscreen for why
-             * this isn't borderless-windowed). The game itself always
-             * renders at its own fixed internal resolution regardless of
-             * this setting - the renderer is responsible for scaling that
-             * up/down and letterboxing to whatever the actual window size
-             * ends up being.
+             * @brief Enter or leave fullscreen, defaulting to a real,
+             * OS-level fullscreen space (see RaylibEngine::SetFullscreen
+             * for why that's the default and when the
+             * FULLSCREEN_STRATEGY_BORDERLESS_WINDOWED fallback is worth
+             * using instead). The game itself always renders at its own
+             * fixed internal resolution regardless of this setting - the
+             * renderer is responsible for scaling that up/down and
+             * letterboxing to whatever the actual window size ends up
+             * being.
+             *
+             * Switching strategy while already fullscreen in the other one
+             * is unsupported - call SetFullscreen( false ) first, then
+             * re-enter fullscreen with the new strategy.
              *
              * @param bFullscreen true to enter fullscreen, false to return
              * to windowed mode;
+             * @param strategy Which fullscreen strategy to use when
+             * entering fullscreen (ignored when bFullscreen is false);
              */
-            virtual void SetFullscreen( bool bFullscreen ) = 0;
+            virtual void SetFullscreen( bool bFullscreen,
+                                       SunLight :: Engines :: IEngine :: FullscreenStrategy strategy =
+                                           SunLight :: Engines :: IEngine :: FULLSCREEN_STRATEGY_REAL ) = 0;
 
             /**
-             * @brief Query whether the window is currently fullscreen (see
-             * @link SetFullscreen).
+             * @brief Query whether the window is currently fullscreen,
+             * regardless of which strategy is active (see @link
+             * SetFullscreen).
              */
             virtual bool GetFullscreen( void ) = 0;
 

--- a/src/engines/iengine.h
+++ b/src/engines/iengine.h
@@ -39,6 +39,14 @@ namespace SunLight  {
 
             public:
 
+            /**
+             * @brief Fullscreen strategy selectable via @see SetFullscreen.
+             */
+            enum FullscreenStrategy  {
+                FULLSCREEN_STRATEGY_REAL               = 0,  // genuine OS-level fullscreen space (default)
+                FULLSCREEN_STRATEGY_BORDERLESS_WINDOWED = 1  // ordinary window resized to the monitor's native resolution
+            };
+
             virtual ~IEngine( void )  {}
 
             /**
@@ -219,20 +227,28 @@ namespace SunLight  {
 
             /**
              * @brief Must be implemented to enter or leave fullscreen on
-             * chosen target engine. Implementations are free to pick
-             * whichever fullscreen strategy suits their backend best (e.g.
-             * borderless-windowed at the current monitor's native
-             * resolution); callers should only rely on @see GetFullscreen
-             * reflecting the resulting state.
+             * chosen target engine, using the requested @see
+             * FullscreenStrategy (defaulting to FULLSCREEN_STRATEGY_REAL -
+             * see RaylibEngine::SetFullscreen for why that's the default
+             * and when FULLSCREEN_STRATEGY_BORDERLESS_WINDOWED is worth
+             * falling back to instead). Callers should only rely on @see
+             * GetFullscreen reflecting the resulting state.
+             *
+             * Switching strategy while already fullscreen in the other one
+             * is unsupported - call SetFullscreen( false ) first, then
+             * re-enter fullscreen with the new strategy.
              *
              * @param bFullscreen true to enter fullscreen, false to return
              * to windowed mode;
+             * @param strategy Which fullscreen strategy to use when
+             * entering fullscreen (ignored when bFullscreen is false);
              */
-            virtual void SetFullscreen( bool bFullscreen ) = 0;
+            virtual void SetFullscreen( bool bFullscreen, FullscreenStrategy strategy = FULLSCREEN_STRATEGY_REAL ) = 0;
 
             /**
              * @brief Must be implemented to report whether the window is
-             * currently fullscreen (see @see SetFullscreen).
+             * currently fullscreen, regardless of which @see
+             * FullscreenStrategy is active (see @see SetFullscreen).
              *
              * @return true if the window is fullscreen, false if windowed;
              */

--- a/src/renderer/tilemaprenderer.cpp
+++ b/src/renderer/tilemaprenderer.cpp
@@ -1279,10 +1279,12 @@ namespace SunLight {
          * Routed through IEngine rather than raylib directly, same as
          * every other window/render primitive TileMapRenderer uses.
          * @param bFullscreen true to enter fullscreen, false for windowed;
+         * @param strategy Which fullscreen strategy to use when entering
+         * fullscreen (ignored when bFullscreen is false);
          */
-        void TileMapRenderer :: SetFullscreen( bool bFullscreen )  {
+        void TileMapRenderer :: SetFullscreen( bool bFullscreen, SunLight :: Engines :: IEngine :: FullscreenStrategy strategy )  {
 
-            SunLight :: Engines :: EngineFactory :: GetEngine().SetFullscreen( bFullscreen );
+            SunLight :: Engines :: EngineFactory :: GetEngine().SetFullscreen( bFullscreen, strategy );
         }
 
         /**

--- a/src/renderer/tilemaprenderer.h
+++ b/src/renderer/tilemaprenderer.h
@@ -238,7 +238,9 @@ namespace SunLight {
             void SetClearBackground( bool bStatus );
             void SetDrawFPS( bool bDrawFPS );
             bool GetDrawFPS( void );
-            void SetFullscreen( bool bFullscreen );
+            void SetFullscreen( bool bFullscreen,
+                               SunLight :: Engines :: IEngine :: FullscreenStrategy strategy =
+                                   SunLight :: Engines :: IEngine :: FULLSCREEN_STRATEGY_REAL );
             bool GetFullscreen( void );
             void SetStretchToFill( bool bStretchToFill );
             bool GetStretchToFill( void );

--- a/tests/mock_engine.h
+++ b/tests/mock_engine.h
@@ -72,6 +72,8 @@ class MockEngine : public SunLight :: Engines :: IEngine  {
     int                                 nLastFilledRectangleHeight = 0;
     SunLight :: Base :: stColor         lastFilledRectangleColor   { 0, 0, 0, 0 };
     bool                                bFullscreen                = false;
+    SunLight :: Engines :: IEngine :: FullscreenStrategy lastFullscreenStrategy =
+        SunLight :: Engines :: IEngine :: FULLSCREEN_STRATEGY_REAL;
     bool                                bWindowResizeable          = false;
     bool                                bSetFontResult             = true;
     std :: string                       strLastSetFontPath;
@@ -135,9 +137,10 @@ class MockEngine : public SunLight :: Engines :: IEngine  {
         return strApplicationDirectoryResult;
     }
 
-    void SetFullscreen( bool bValue )  {
+    void SetFullscreen( bool bValue, SunLight :: Engines :: IEngine :: FullscreenStrategy strategy = SunLight :: Engines :: IEngine :: FULLSCREEN_STRATEGY_REAL )  {
         nSetFullscreenCalls++;
         bFullscreen = bValue;
+        lastFullscreenStrategy = strategy;
     }
 
     bool GetFullscreen( void )  {

--- a/tests/test_tilemaprenderer.cpp
+++ b/tests/test_tilemaprenderer.cpp
@@ -181,6 +181,24 @@ TEST_SUITE( "renderer/TileMapRenderer" )  {
         CHECK( fixture.engine.lastFilledRectangleColor.nAlpha == 128 );
     }
 
+    TEST_CASE( "SetFullscreen forwards straight through to IEngine, defaulting to the real strategy" )  {
+
+        MockEngineFixture  fixture;
+        TileMapRenderer    renderer( 800, 600, "test", -1, false );
+
+        renderer.SetFullscreen( true );
+
+        CHECK( fixture.engine.nSetFullscreenCalls == 1 );
+        CHECK( fixture.engine.bFullscreen == true );
+        CHECK( fixture.engine.lastFullscreenStrategy == SunLight :: Engines :: IEngine :: FULLSCREEN_STRATEGY_REAL );
+
+        renderer.SetFullscreen( false, SunLight :: Engines :: IEngine :: FULLSCREEN_STRATEGY_BORDERLESS_WINDOWED );
+
+        CHECK( fixture.engine.nSetFullscreenCalls == 2 );
+        CHECK( fixture.engine.bFullscreen == false );
+        CHECK( fixture.engine.lastFullscreenStrategy == SunLight :: Engines :: IEngine :: FULLSCREEN_STRATEGY_BORDERLESS_WINDOWED );
+    }
+
     TEST_CASE( "DrawText forwards straight through to IEngine" )  {
 
         MockEngineFixture  fixture;


### PR DESCRIPTION
## Why

v0.13.2 switched `SetFullscreen` from borderless-windowed to real `ToggleFullscreen()` to fix the macOS Dock overlap, but flagged an open risk: real fullscreen performs a genuine monitor video-mode switch to the window's *current* size, not the monitor's native resolution the way borderless-windowed did — a real reliability concern on Windows/some Linux window managers if the game's window size doesn't match the player's monitor.

This lets callers opt back into borderless-windowed on a per-call basis without reverting the default behavior everyone else gets.

## What changed

`IEngine::FullscreenStrategy` (`FULLSCREEN_STRATEGY_REAL` default, `FULLSCREEN_STRATEGY_BORDERLESS_WINDOWED` fallback), added as a defaulted second parameter on `SetFullscreen` across `IEngine` → `RaylibEngine` and `IDrawSurface` → `TileMapRenderer`. The default is repeated identically at every override — matching this codebase's existing `ITileMap::MapAlignment`/`LoadMap` precedent — because default arguments on virtual functions are resolved by the *call site's static type*, not virtually dispatched; keeping the same default everywhere sidesteps that gotcha entirely.

`RaylibEngine::GetFullscreen` now checks both `FLAG_FULLSCREEN_MODE` and `FLAG_BORDERLESS_WINDOWED_MODE`, so it correctly reflects state under either strategy (previously it only checked the real-fullscreen flag).

Switching strategy while already fullscreen in the other one is documented as unsupported (call `SetFullscreen(false)` first, then re-enter with the new strategy) — both raylib toggles assume theirs is the only active fullscreen strategy, and mixing them without returning to windowed mode first can leave stale window flags set.

## Testing

- `mock_engine.h` updated to match `IEngine`'s new signature and records the last strategy passed.
- New MockEngine-backed test verifying default-vs-explicit-strategy forwarding through `TileMapRenderer::SetFullscreen`.
- Full suite: 83/83 passing.

## Version

MINOR (0.13.2 → 0.14.0) — new public API (enum + new default parameter on an existing interface method).

🤖 Generated with [Claude Code](https://claude.com/claude-code)