### PR TITLE
IFileSystem::ToVirtualPath — fix real Windows paths used as illegal mount points

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
-project (sunlight VERSION 0.16.0)
+project (sunlight VERSION 0.17.0)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/src/filesystem/ifilesystem.cpp
+++ b/src/filesystem/ifilesystem.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "filesystem/ifilesystem.h"
+
+
+namespace SunLight  {
+    namespace FileSystem  {
+
+        /**
+         * @brief See this method's own declaration (ifilesystem.h) for
+         * the full rationale.
+         */
+        std :: string IFileSystem :: ToVirtualPath( const std :: string &strRealPath )  {
+
+            std :: string  strVirtual = strRealPath;
+
+            for( char &c : strVirtual )  {
+                if( c == '\\' )
+                    c = '/';
+            }
+
+            if( ( strVirtual.size() >= 2 ) && ( strVirtual[1] == ':' ) )
+                strVirtual = strVirtual.substr( 2 );
+
+            return strVirtual;
+        }
+    }
+}

--- a/src/filesystem/ifilesystem.h
+++ b/src/filesystem/ifilesystem.h
@@ -49,6 +49,41 @@ namespace SunLight  {
             virtual ~IFileSystem( void )  {}
 
             /**
+             * @brief Converts a real, OS-native path into its own legal
+             * virtual-path equivalent - normalizing '\' to '/' and
+             * stripping a Windows drive letter prefix ("C:", "D:", ...).
+             * A real path is always safe to pass as @see Mount's own
+             * strRealPath (source) argument, in whatever native format the
+             * OS gives it - but never as strMountPoint (destination): a
+             * raw Windows path's own ':' trips the underlying PhysFS
+             * backend's path-legality check outright ("filename is
+             * illegal or insecure"), a real, live-reproduced bug (a
+             * consumer mounting it's own real application directory "at
+             * itself" - Mount(realPath, realPath, ...), the natural,
+             * obvious thing to want to do - silently failed on Windows
+             * this way, never on Mac/Linux, since a POSIX absolute path
+             * never contains ':' to begin with).
+             *
+             * Idempotent - safe to call on a string that's already a
+             * legal virtual path (eg. "/", or this method's own prior
+             * output), since neither transformation touches it further.
+             * A consumer needing to mount it's own real directory "at
+             * itself" must call this explicitly and use the *same*
+             * resulting string both as Mount()'s own mountPoint argument
+             * and as the prefix for any virtual path it later constructs
+             * against that mount (eg. exposing it to a scripting layer as
+             * an "application directory" global) - Mount() itself cannot
+             * safely do this conversion internally on the caller's
+             * behalf, since ReadFile/Exists lookups against virtual paths
+             * built from the *unconverted* real path would then no longer
+             * match whatever Mount() actually mounted things at.
+             *
+             * @param strRealPath Real, OS-native path to convert;
+             * @return strRealPath's own equivalent, legal virtual path;
+             */
+            static std :: string ToVirtualPath( const std :: string &strRealPath );
+
+            /**
              * @brief Must be implemented to perform whatever one-time
              * startup the concrete backend needs before @see Mount can be
              * called - eg. PhysFS's own PHYSFS_init(). Safe to call more

--- a/tests/test_ifilesystem.cpp
+++ b/tests/test_ifilesystem.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) since 2021 by PopolonY2k and Leidson Campos A. Ferreira
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include <doctest/doctest.h>
+#include "filesystem/ifilesystem.h"
+
+using namespace SunLight :: FileSystem;
+
+TEST_SUITE( "filesystem/IFileSystem::ToVirtualPath" )  {
+
+    TEST_CASE( "Strips a Windows drive letter and normalizes backslashes" )  {
+
+        CHECK( IFileSystem :: ToVirtualPath( "D:\\Projects\\game-engine\\build\\games\\caravellius.zip" )
+               == "/Projects/game-engine/build/games/caravellius.zip" );
+    }
+
+    TEST_CASE( "Strips a lowercase drive letter just as well" )  {
+
+        CHECK( IFileSystem :: ToVirtualPath( "c:\\Users\\dev" ) == "/Users/dev" );
+    }
+
+    TEST_CASE( "Normalizes backslashes even without a drive letter" )  {
+
+        // eg. a UNC-style or already-rooted path with no drive letter -
+        // strVirtual[1] isn't ':', so the drive-letter strip is skipped,
+        // but every '\' still becomes '/'.
+        CHECK( IFileSystem :: ToVirtualPath( "\\\\server\\share\\file.txt" ) == "//server/share/file.txt" );
+    }
+
+    TEST_CASE( "Leaves a POSIX absolute path untouched" )  {
+
+        CHECK( IFileSystem :: ToVirtualPath( "/home/user/game" ) == "/home/user/game" );
+    }
+
+    TEST_CASE( "Leaves a relative path untouched" )  {
+
+        CHECK( IFileSystem :: ToVirtualPath( "samples/tilemaprenderer/" ) == "samples/tilemaprenderer/" );
+    }
+
+    TEST_CASE( "Is idempotent - safe to call on it's own prior output" )  {
+
+        std :: string  strOnce = IFileSystem :: ToVirtualPath( "D:\\Projects\\game" );
+        std :: string  strTwice = IFileSystem :: ToVirtualPath( strOnce );
+
+        CHECK( strOnce == strTwice );
+        CHECK( strTwice == "/Projects/game" );
+    }
+
+    TEST_CASE( "Handles empty and single-character strings without crashing" )  {
+
+        CHECK( IFileSystem :: ToVirtualPath( "" ) == "" );
+        CHECK( IFileSystem :: ToVirtualPath( "/" ) == "/" );
+        CHECK( IFileSystem :: ToVirtualPath( "D" ) == "D" );
+    }
+}


### PR DESCRIPTION
## Problem

Scarab (the engine built on sunlight) failed to launch on Windows the moment it tried to mount a `.zip` archive bundle:

```
[FATAL] - Error mounting archive => D:\Projects\C_CPP\game-engine\build\games\caravellius\caravellius.zip
```

A PhysFS diagnostic surfaced the real cause: `PHYSFS_mount failed: filename is illegal or insecure`.

The same failure mode already existed in Scarab's loose-directory launch too (`Mount(strAppDir, strAppDir, true)` — mounting the executable's own directory "at itself"), just silently masked by `PhysFsFileSystem::EnsureReady()`'s own CWD fallback in ordinary dev launches, where CWD and the app directory happen to coincide.

## Root cause — verified against PhysFS's own source

`PHYSFS_mount()`'s `mountPoint` argument is run through PhysFS's internal `sanitizePlatformIndependentPath()`, which bails with `PHYSFS_ERR_BAD_FILENAME` on either `:` or `\\` anywhere in the string (confirmed directly in `physfs.c`). A raw Windows path's drive-letter `:` trips this outright, regardless of slash style — real on Windows, never on Mac/Linux (a POSIX absolute path never contains `:`). The same sanitizer is confirmed to never run against `Mount()`'s own `strRealPath` (source) argument — only `strMountPoint` (destination), so a real OS path is always safe there in whatever native format the OS gives it.

Read-path lookups (`ReadFile`/`Exists`) are a separate check from mount-point legality — with the mount fixed but the read-path prefix left unconverted, a consumer's own virtual-path construction (e.g. `main.lua`'s `dofile`) still fails to resolve. So the fix can't just live inside `Mount()` silently sanitizing its own argument — the caller has to use the *same* converted value consistently everywhere it builds a virtual path against that mount.

## Fix

New `IFileSystem::ToVirtualPath(const std::string&) -> std::string` (static): normalizes `\\` to `/` and strips a Windows drive-letter prefix. Idempotent — safe to call on a string that's already a legal virtual path.

Deliberately **not** applied automatically inside `PhysFsFileSystem::Mount()` — a consumer mounting its own real directory "at itself" calls this explicitly and reuses the same converted string both for the `Mount()` call and for any virtual path it later constructs against that mount (e.g. exposing it to a scripting layer as an "application directory" global).

Kept on `IFileSystem`, not `PhysFsFileSystem` — a consumer never needs to include a PhysFS-specific header directly to use it, matching this project's own backend-abstraction rule (`CLAUDE.md`: "call sites elsewhere should never need raylib/PhysFS types directly").

No changes to `Mount()`'s existing signature or behavior.

## Testing

- `tests/test_ifilesystem.cpp` (new): 7 doctest cases — drive-letter strip, backslash normalization (with/without a drive letter), POSIX/relative-path passthrough, idempotency, empty/edge-case strings. Pure string logic, no PhysFS/window dependency.
- Full suite: **96/96 passing**.
- Root-cause claims verified directly against PhysFS's vendored source (`sanitizePlatformIndependentPath` in `physfs.c`), not just the write-up.
- Reproduced and verified live on Windows (MSVC 19.44) against Scarab — both loose-directory and `.zip` launches, before/after.

## Version

MINOR (0.16.0 → 0.17.0) — new public method on `IFileSystem`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)